### PR TITLE
various typos in comments

### DIFF
--- a/include/mb1242.h
+++ b/include/mb1242.h
@@ -63,10 +63,10 @@ private:
     bool new_data_; // Whether or not new data is ready to be returned
     I2C *i2c_; // The i2c object used for communication
     bool ready_to_ping_; // Whether the sensor is ready to make another measurement
-    uint8_t buffer_[2]; // for recieving data from the sensor
+    uint8_t buffer_[2]; // for receiving data from the sensor
     bool sensor_present_; // Flag of whether we have received data from the sensor
-    
-    
+
+
 public:
     I2CSonar();
     void init(I2C *_i2c);

--- a/lib/CMSIS/CM4/DeviceSupport/ST/STM32F4xx/stm32f4xx.h
+++ b/lib/CMSIS/CM4/DeviceSupport/ST/STM32F4xx/stm32f4xx.h
@@ -4,24 +4,24 @@
   * @author  MCD Application Team
   * @version V1.6.1
   * @date    21-October-2015
-  * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer Header File. 
-  *          This file contains all the peripheral register's definitions, bits 
-  *          definitions and memory mapping for STM32F4xx devices.            
-  *            
+  * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for STM32F4xx devices.
+  *
   *          The file is the unique include file that the application programmer
   *          is using in the C source code, usually in main.c. This file contains:
   *           - Configuration section that allows to select:
   *              - The device used in the target application
-  *              - To use or not the peripheral’s drivers in application code(i.e. 
-  *                code will be based on direct access to peripheral’s registers 
-  *                rather than drivers API), this option is controlled by 
+  *              - To use or not the peripheral's drivers in application code(i.e.
+  *                code will be based on direct access to peripheral's registers
+  *                rather than drivers API), this option is controlled by
   *                "#define USE_STDPERIPH_DRIVER"
-  *              - To change few application-specific parameters such as the HSE 
+  *              - To change few application-specific parameters such as the HSE
   *                crystal frequency
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
-  *  
+  *           - Macros to access peripheral's registers hardware
+  *
   ******************************************************************************
   * @attention
   *
@@ -33,14 +33,14 @@
   *
   *        http://www.st.com/software_license_agreement_liberty_v2
   *
-  * Unless required by applicable law or agreed to in writing, software 
-  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   * See the License for the specific language governing permissions and
   * limitations under the License.
   *
   ******************************************************************************
-  */ 
+  */
 
 /** @addtogroup CMSIS
   * @{
@@ -49,46 +49,46 @@
 /** @addtogroup stm32f4xx
   * @{
   */
-    
+
 #ifndef __STM32F4xx_H
 #define __STM32F4xx_H
 
 #ifdef __cplusplus
  extern "C" {
 #endif /* __cplusplus */
-  
+
 /** @addtogroup Library_configuration_section
   * @{
   */
-  
+
 /* Uncomment the line below according to the target STM32 device used in your
-   application 
+   application
   */
 
 #if !defined(STM32F40_41xxx) && !defined(STM32F427_437xx) && !defined(STM32F429_439xx) && !defined(STM32F401xx) && !defined(STM32F410xx) && \
     !defined(STM32F411xE) && !defined(STM32F446xx) && !defined(STM32F469_479xx)
-  /* #define STM32F40_41xxx */   /*!< STM32F405RG, STM32F405VG, STM32F405ZG, STM32F415RG, STM32F415VG, STM32F415ZG,  
-                                      STM32F407VG, STM32F407VE, STM32F407ZG, STM32F407ZE, STM32F407IG, STM32F407IE, 
+  /* #define STM32F40_41xxx */   /*!< STM32F405RG, STM32F405VG, STM32F405ZG, STM32F415RG, STM32F415VG, STM32F415ZG,
+                                      STM32F407VG, STM32F407VE, STM32F407ZG, STM32F407ZE, STM32F407IG, STM32F407IE,
                                       STM32F417VG, STM32F417VE, STM32F417ZG, STM32F417ZE, STM32F417IG and STM32F417IE Devices */
 
-  /* #define STM32F427_437xx */  /*!< STM32F427VG, STM32F427VI, STM32F427ZG, STM32F427ZI, STM32F427IG, STM32F427II,  
+  /* #define STM32F427_437xx */  /*!< STM32F427VG, STM32F427VI, STM32F427ZG, STM32F427ZI, STM32F427IG, STM32F427II,
                                       STM32F437VG, STM32F437VI, STM32F437ZG, STM32F437ZI, STM32F437IG, STM32F437II Devices */
 
-  /* #define STM32F429_439xx */  /*!< STM32F429VG, STM32F429VI, STM32F429ZG, STM32F429ZI, STM32F429BG, STM32F429BI,  
-                                      STM32F429NG, STM32F439NI, STM32F429IG, STM32F429II, STM32F439VG, STM32F439VI, 
+  /* #define STM32F429_439xx */  /*!< STM32F429VG, STM32F429VI, STM32F429ZG, STM32F429ZI, STM32F429BG, STM32F429BI,
+                                      STM32F429NG, STM32F439NI, STM32F429IG, STM32F429II, STM32F439VG, STM32F439VI,
                                       STM32F439ZG, STM32F439ZI, STM32F439BG, STM32F439BI, STM32F439NG, STM32F439NI,
                                       STM32F439IG and STM32F439II Devices */
 
-  /* #define STM32F401xx */      /*!< STM32F401CB, STM32F401CC,  STM32F401RB, STM32F401RC, STM32F401VB, STM32F401VC  
+  /* #define STM32F401xx */      /*!< STM32F401CB, STM32F401CC,  STM32F401RB, STM32F401RC, STM32F401VB, STM32F401VC
                                       STM32F401CD, STM32F401RD, STM32F401VD, STM32F401CExx, STM32F401RE and STM32F401VE Devices */
 
   /* #define STM32F410xx */      /*!< STM32F410T8, STM32F410TB, STM32F410C8, STM32F410CB, STM32F410R8 and STM32F410RB  */
 
   /* #define STM32F411xE */      /*!< STM32F411CD, STM32F411RD, STM32F411VD, STM32F411CE, STM32F411RE and STM32F411VE Devices */
-  
-  /* #define STM32F446xx */      /*!< STM32F446MC, STM32F446ME, STM32F446RC, STM32F446RE, STM32F446VC, STM32F446VE, STM32F446ZC 
+
+  /* #define STM32F446xx */      /*!< STM32F446MC, STM32F446ME, STM32F446RC, STM32F446RE, STM32F446VC, STM32F446VE, STM32F446ZC
                                       and STM32F446ZE Devices */
-   
+
   /* #define STM32F469_479xx */  /*!< STM32F479AI, STM32F479II, STM32F479BI, STM32F479NI, STM32F479AG, STM32F479IG, STM32F479BG,
                                       STM32F479NG, STM32F479AE, STM32F479IE, STM32F479BE, STM32F479NE Devices */
 #endif /* STM32F40_41xxx && STM32F427_437xx && STM32F429_439xx && STM32F401xx && STM32F410xx && STM32F411xE && STM32F446xx && STM32F469_479xx */
@@ -108,47 +108,47 @@
   */
 
 #if !defined(STM32F40_41xxx) && !defined(STM32F427_437xx) && !defined(STM32F429_439xx) && !defined(STM32F401xx) && !defined(STM32F410xx) && \
-    !defined(STM32F411xE) && !defined(STM32F446xx) && !defined(STM32F469_479xx) 
+    !defined(STM32F411xE) && !defined(STM32F446xx) && !defined(STM32F469_479xx)
  #error "Please select first the target STM32F4xx device used in your application (in stm32f4xx.h file)"
 #endif
 
 #if !defined  (USE_STDPERIPH_DRIVER)
 /**
  * @brief Comment the line below if you will not use the peripherals drivers.
-   In this case, these drivers will not be included and the application code will 
-   be based on direct access to peripherals registers 
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
    */
   /*#define USE_STDPERIPH_DRIVER */
 #endif /* USE_STDPERIPH_DRIVER */
 
 /**
  * @brief In the following line adjust the value of External High Speed oscillator (HSE)
-   used in your application 
-   
+   used in your application
+
    Tip: To avoid modifying this file each time you need to use different HSE, you
         can define the HSE value in your toolchain compiler preprocessor.
-  */           
+  */
 #if defined(STM32F40_41xxx) || defined(STM32F427_437xx)  || defined(STM32F429_439xx) || defined(STM32F401xx) || \
     defined(STM32F410xx) || defined(STM32F411xE) || defined(STM32F469_479xx)
- #if !defined  (HSE_VALUE) 
+ #if !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
  #endif /* HSE_VALUE */
 #elif defined(STM32F446xx)
- #if !defined  (HSE_VALUE) 
+ #if !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
  #endif /* HSE_VALUE */
 #endif /* STM32F40_41xxx || STM32F427_437xx || STM32F429_439xx || STM32F401xx || STM32F411xE || STM32F469_479xx */
 /**
- * @brief In the following line adjust the External High Speed oscillator (HSE) Startup 
-   Timeout value 
+ * @brief In the following line adjust the External High Speed oscillator (HSE) Startup
+   Timeout value
    */
-#if !defined  (HSE_STARTUP_TIMEOUT) 
+#if !defined  (HSE_STARTUP_TIMEOUT)
   #define HSE_STARTUP_TIMEOUT    ((uint16_t)0x05000)   /*!< Time out for HSE start up */
-#endif /* HSE_STARTUP_TIMEOUT */   
+#endif /* HSE_STARTUP_TIMEOUT */
 
-#if !defined  (HSI_VALUE)   
+#if !defined  (HSI_VALUE)
   #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
-#endif /* HSI_VALUE */   
+#endif /* HSI_VALUE */
 
 /**
  * @brief STM32F4XX Standard Peripherals Library version number V1.6.1
@@ -156,7 +156,7 @@
 #define __STM32F4XX_STDPERIPH_VERSION_MAIN   (0x01) /*!< [31:24] main version */
 #define __STM32F4XX_STDPERIPH_VERSION_SUB1   (0x06) /*!< [23:16] sub1 version */
 #define __STM32F4XX_STDPERIPH_VERSION_SUB2   (0x01) /*!< [15:8]  sub2 version */
-#define __STM32F4XX_STDPERIPH_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
+#define __STM32F4XX_STDPERIPH_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
 #define __STM32F4XX_STDPERIPH_VERSION        ((__STM32F4XX_STDPERIPH_VERSION_MAIN << 24)\
                                              |(__STM32F4XX_STDPERIPH_VERSION_SUB1 << 16)\
                                              |(__STM32F4XX_STDPERIPH_VERSION_SUB2 << 8)\
@@ -171,7 +171,7 @@
   */
 
 /**
- * @brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * @brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 #define __CM4_REV                 0x0001  /*!< Core revision r0p1                            */
 #define __MPU_PRESENT             1       /*!< STM32F4XX provides an MPU                     */
@@ -180,8 +180,8 @@
 #define __FPU_PRESENT             1       /*!< FPU present                                   */
 
 /**
- * @brief STM32F4XX Interrupt Number Definition, according to the selected device 
- *        in @ref Library_configuration_section 
+ * @brief STM32F4XX Interrupt Number Definition, according to the selected device
+ *        in @ref Library_configuration_section
  */
 typedef enum IRQn
 {
@@ -353,7 +353,7 @@ typedef enum IRQn
   SAI1_IRQn                   = 87,     /*!< SAI1 global Interrupt                                             */
   DMA2D_IRQn                  = 90      /*!< DMA2D global Interrupt                                            */
 #endif /* STM32F427_437xx */
-    
+
 #if defined(STM32F429_439xx)
   CAN1_TX_IRQn                = 19,     /*!< CAN1 TX Interrupt                                                 */
   CAN1_RX0_IRQn               = 20,     /*!< CAN1 RX0 Interrupt                                                */
@@ -464,7 +464,7 @@ typedef enum IRQn
   FMPI2C1_ER_IRQn             = 96,     /*!< FMPI2C1 Error Interrupt                                           */
   LPTIM1_IRQn                 = 97      /*!< LPTIM1 interrupt                                                  */
 #endif /* STM32F410xx */
-   
+
 #if defined(STM32F401xx) || defined(STM32F411xE)
   EXTI9_5_IRQn                = 23,     /*!< External Line[9:5] Interrupts                                     */
   TIM1_BRK_TIM9_IRQn          = 24,     /*!< TIM1 Break interrupt and TIM9 global interrupt                    */
@@ -656,7 +656,7 @@ typedef enum IRQn
   SPDIF_RX_IRQn               = 94,     /*!< QuadSPI global Interrupt                                          */
   FMPI2C1_EV_IRQn             = 95,     /*!< FMPI2C Event Interrupt                                            */
   FMPI2C1_ER_IRQn             = 96      /*!< FMPCI2C Error Interrupt                                           */
-#endif /* STM32F446xx */    
+#endif /* STM32F446xx */
 } IRQn_Type;
 
 /**
@@ -669,7 +669,7 @@ typedef enum IRQn
 
 /** @addtogroup Exported_types
   * @{
-  */  
+  */
 /*!< STM32F10x Standard Peripheral Library old types (maintained for legacy purpose) */
 typedef int32_t  s32;
 typedef int16_t s16;
@@ -716,10 +716,10 @@ typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrorStatus;
 
 /** @addtogroup Peripheral_registers_structures
   * @{
-  */   
+  */
 
-/** 
-  * @brief Analog to Digital Converter  
+/**
+  * @brief Analog to Digital Converter
   */
 
 typedef struct
@@ -755,8 +755,8 @@ typedef struct
 } ADC_Common_TypeDef;
 
 
-/** 
-  * @brief Controller Area Network TxMailBox 
+/**
+  * @brief Controller Area Network TxMailBox
   */
 
 typedef struct
@@ -767,10 +767,10 @@ typedef struct
   __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
-/** 
-  * @brief Controller Area Network FIFOMailBox 
+/**
+  * @brief Controller Area Network FIFOMailBox
   */
-  
+
 typedef struct
 {
   __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
@@ -779,20 +779,20 @@ typedef struct
   __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
-/** 
-  * @brief Controller Area Network FilterRegister 
+/**
+  * @brief Controller Area Network FilterRegister
   */
-  
+
 typedef struct
 {
   __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
   __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
-/** 
-  * @brief Controller Area Network 
+/**
+  * @brief Controller Area Network
   */
-  
+
 typedef struct
 {
   __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
@@ -815,7 +815,7 @@ typedef struct
   __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
   __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
-  uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
+  uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
 
@@ -834,8 +834,8 @@ typedef struct
 }CEC_TypeDef;
 #endif /* STM32F446xx */
 
-/** 
-  * @brief CRC calculation unit 
+/**
+  * @brief CRC calculation unit
   */
 
 typedef struct
@@ -847,7 +847,7 @@ typedef struct
   __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
-/** 
+/**
   * @brief Digital to Analog Converter
   */
 
@@ -869,7 +869,7 @@ typedef struct
   __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
-/** 
+/**
   * @brief Debug MCU
   */
 
@@ -881,7 +881,7 @@ typedef struct
   __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
-/** 
+/**
   * @brief DCMI
   */
 
@@ -900,7 +900,7 @@ typedef struct
   __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
-/** 
+/**
   * @brief DMA Controller
   */
 
@@ -921,8 +921,8 @@ typedef struct
   __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
   __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
- 
-/** 
+
+/**
   * @brief DMA2D Controller
   */
 
@@ -954,7 +954,7 @@ typedef struct
 } DMA2D_TypeDef;
 
 #if defined(STM32F469_479xx)
-/** 
+/**
   * @brief DSI Controller
   */
 
@@ -964,11 +964,11 @@ typedef struct
   __IO uint32_t CR;             /*!< DSI Host Control Register,                                 Address offset: 0x04       */
   __IO uint32_t CCR;            /*!< DSI HOST Clock Control Register,                           Address offset: 0x08       */
   __IO uint32_t LVCIDR;         /*!< DSI Host LTDC VCID Register,                               Address offset: 0x0C       */
-  __IO uint32_t LCOLCR;         /*!< DSI Host LTDC Color Coding Register,                       Address offset: 0x10       */ 
+  __IO uint32_t LCOLCR;         /*!< DSI Host LTDC Color Coding Register,                       Address offset: 0x10       */
   __IO uint32_t LPCR;           /*!< DSI Host LTDC Polarity Configuration Register,             Address offset: 0x14       */
   __IO uint32_t LPMCR;          /*!< DSI Host Low-Power Mode Configuration Register,            Address offset: 0x18       */
   uint32_t      RESERVED0[4];   /*!< Reserved, 0x1C - 0x2B                                                                 */
-  __IO uint32_t PCR;            /*!< DSI Host Protocol Configuration Register,                  Address offset: 0x2C       */ 
+  __IO uint32_t PCR;            /*!< DSI Host Protocol Configuration Register,                  Address offset: 0x2C       */
   __IO uint32_t GVCIDR;         /*!< DSI Host Generic VCID Register,                            Address offset: 0x30       */
   __IO uint32_t MCR;            /*!< DSI Host Mode Configuration Register,                      Address offset: 0x34       */
   __IO uint32_t VMCR;           /*!< DSI Host Video Mode Configuration Register,                Address offset: 0x38       */
@@ -982,18 +982,18 @@ typedef struct
   __IO uint32_t VVBPCR;         /*!< DSI Host Video VBP Configuration Register,                 Address offset: 0x58       */
   __IO uint32_t VVFPCR;         /*!< DSI Host Video VFP Configuration Register,                 Address offset: 0x5C       */
   __IO uint32_t VVACR;          /*!< DSI Host Video VA Configuration Register,                  Address offset: 0x60       */
-  __IO uint32_t LCCR;           /*!< DSI Host LTDC Command Configuration Register,              Address offset: 0x64       */ 
+  __IO uint32_t LCCR;           /*!< DSI Host LTDC Command Configuration Register,              Address offset: 0x64       */
   __IO uint32_t CMCR;           /*!< DSI Host Command Mode Configuration Register,              Address offset: 0x68       */
   __IO uint32_t GHCR;           /*!< DSI Host Generic Header Configuration Register,            Address offset: 0x6C       */
   __IO uint32_t GPDR;           /*!< DSI Host Generic Payload Data Register,                    Address offset: 0x70       */
   __IO uint32_t GPSR;           /*!< DSI Host Generic Packet Status Register,                   Address offset: 0x74       */
   __IO uint32_t TCCR[6];        /*!< DSI Host Timeout Counter Configuration Register,           Address offset: 0x78-0x8F  */
-  __IO uint32_t TDCR;           /*!< DSI Host 3D Configuration Register,                        Address offset: 0x90       */ 
+  __IO uint32_t TDCR;           /*!< DSI Host 3D Configuration Register,                        Address offset: 0x90       */
   __IO uint32_t CLCR;           /*!< DSI Host Clock Lane Configuration Register,                Address offset: 0x94       */
   __IO uint32_t CLTCR;          /*!< DSI Host Clock Lane Timer Configuration Register,          Address offset: 0x98       */
   __IO uint32_t DLTCR;          /*!< DSI Host Data Lane Timer Configuration Register,           Address offset: 0x9C       */
-  __IO uint32_t PCTLR;          /*!< DSI Host PHY Control Register,                             Address offset: 0xA0       */ 
-  __IO uint32_t PCONFR;         /*!< DSI Host PHY Configuration Register,                       Address offset: 0xA4       */ 
+  __IO uint32_t PCTLR;          /*!< DSI Host PHY Control Register,                             Address offset: 0xA0       */
+  __IO uint32_t PCONFR;         /*!< DSI Host PHY Configuration Register,                       Address offset: 0xA4       */
   __IO uint32_t PUCR;           /*!< DSI Host PHY ULPS Control Register,                        Address offset: 0xA8       */
   __IO uint32_t PTTCR;          /*!< DSI Host PHY TX Triggers Configuration Register,           Address offset: 0xAC       */
   __IO uint32_t PSR;            /*!< DSI Host PHY Status Register,                              Address offset: 0xB0       */
@@ -1017,7 +1017,7 @@ typedef struct
   __IO uint32_t VHSACCR;        /*!< DSI Host Video HSA Current Configuration Register,         Address offset: 0x148      */
   __IO uint32_t VHBPCCR;        /*!< DSI Host Video HBP Current Configuration Register,         Address offset: 0x14C      */
   __IO uint32_t VLCCR;          /*!< DSI Host Video Line Current Configuration Register,        Address offset: 0x150      */
-  __IO uint32_t VVSACCR;        /*!< DSI Host Video VSA Current Configuration Register,         Address offset: 0x154      */ 
+  __IO uint32_t VVSACCR;        /*!< DSI Host Video VSA Current Configuration Register,         Address offset: 0x154      */
   __IO uint32_t VVBPCCR;        /*!< DSI Host Video VBP Current Configuration Register,         Address offset: 0x158      */
   __IO uint32_t VVFPCCR;        /*!< DSI Host Video VFP Current Configuration Register,         Address offset: 0x15C      */
   __IO uint32_t VVACCR;         /*!< DSI Host Video VA Current Configuration Register,          Address offset: 0x160      */
@@ -1036,7 +1036,7 @@ typedef struct
 } DSI_TypeDef;
 #endif /* STM32F469_479xx */
 
-/** 
+/**
   * @brief Ethernet MAC
   */
 
@@ -1110,7 +1110,7 @@ typedef struct
   __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
-/** 
+/**
   * @brief External Interrupt/Event Controller
   */
 
@@ -1124,7 +1124,7 @@ typedef struct
   __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
-/** 
+/**
   * @brief FLASH Registers
   */
 
@@ -1140,28 +1140,28 @@ typedef struct
 } FLASH_TypeDef;
 
 #if defined(STM32F40_41xxx)
-/** 
+/**
   * @brief Flexible Static Memory Controller
   */
 
 typedef struct
 {
   __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
-} FSMC_Bank1_TypeDef; 
+} FSMC_Bank1_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller Bank1E
   */
-  
+
 typedef struct
 {
   __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller Bank2
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
@@ -1172,10 +1172,10 @@ typedef struct
   __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
 } FSMC_Bank2_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller Bank3
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
@@ -1186,10 +1186,10 @@ typedef struct
   __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FSMC_Bank3_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller Bank4
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
@@ -1197,32 +1197,32 @@ typedef struct
   __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
   __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
   __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
-} FSMC_Bank4_TypeDef; 
+} FSMC_Bank4_TypeDef;
 #endif /* STM32F40_41xxx */
 
 #if defined(STM32F427_437xx) || defined(STM32F429_439xx) || defined(STM32F446xx) || defined(STM32F469_479xx)
-/** 
+/**
   * @brief Flexible Memory Controller
   */
 
 typedef struct
 {
   __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
-} FMC_Bank1_TypeDef; 
+} FMC_Bank1_TypeDef;
 
-/** 
+/**
   * @brief Flexible Memory Controller Bank1E
   */
-  
+
 typedef struct
 {
   __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FMC_Bank1E_TypeDef;
 
-/** 
+/**
   * @brief Flexible Memory Controller Bank2
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
@@ -1233,10 +1233,10 @@ typedef struct
   __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
 } FMC_Bank2_TypeDef;
 
-/** 
+/**
   * @brief Flexible Memory Controller Bank3
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
@@ -1247,10 +1247,10 @@ typedef struct
   __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FMC_Bank3_TypeDef;
 
-/** 
+/**
   * @brief Flexible Memory Controller Bank4
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
@@ -1258,12 +1258,12 @@ typedef struct
   __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
   __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
   __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
-} FMC_Bank4_TypeDef; 
+} FMC_Bank4_TypeDef;
 
-/** 
+/**
   * @brief Flexible Memory Controller Bank5_6
   */
-  
+
 typedef struct
 {
   __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
@@ -1271,10 +1271,10 @@ typedef struct
   __IO uint32_t SDCMR;       /*!< SDRAM Command Mode register,    Address offset: 0x150  */
   __IO uint32_t SDRTR;       /*!< SDRAM Refresh Timer register,   Address offset: 0x154  */
   __IO uint32_t SDSR;        /*!< SDRAM Status register,          Address offset: 0x158  */
-} FMC_Bank5_6_TypeDef; 
+} FMC_Bank5_6_TypeDef;
 #endif /* STM32F427_437xx ||  STM32F429_439xx || STM32F446xx || STM32F469_479xx */
 
-/** 
+/**
   * @brief General Purpose I/O
   */
 
@@ -1292,10 +1292,10 @@ typedef struct
   __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
-/** 
+/**
   * @brief System configuration controller
   */
-  
+
 typedef struct
 {
   __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
@@ -1308,12 +1308,12 @@ typedef struct
   uint32_t      RESERVED1[2]; /*!< Reserved, 0x24-0x28                                                          */
   __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x2C      */
 #else  /* STM32F40_41xxx || STM32F427_437xx || STM32F429_439xx || STM32F401xx || STM32F411xE || STM32F446xx || STM32F469_479xx */
-  uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */ 
+  uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
   __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 #endif /* STM32F410xx */
 } SYSCFG_TypeDef;
 
-/** 
+/**
   * @brief Inter-integrated Circuit Interface
   */
 
@@ -1362,7 +1362,7 @@ typedef struct
 }FMPI2C_TypeDef;
 #endif /* STM32F410xx || STM32F446xx */
 
-/** 
+/**
   * @brief Independent WATCHDOG
   */
 
@@ -1374,10 +1374,10 @@ typedef struct
   __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
-/** 
+/**
   * @brief LCD-TFT Display Controller
   */
-  
+
 typedef struct
 {
   uint32_t      RESERVED0[2];  /*!< Reserved, 0x00-0x04 */
@@ -1397,14 +1397,14 @@ typedef struct
   __IO uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
   __IO uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
   __IO uint32_t CDSR;         /*!< LTDC Current Display Status Register,                       Address offset: 0x48 */
-} LTDC_TypeDef;  
+} LTDC_TypeDef;
 
-/** 
+/**
   * @brief LCD-TFT Display layer x Controller
   */
-  
+
 typedef struct
-{  
+{
   __IO uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
   __IO uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
   __IO uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
@@ -1422,7 +1422,7 @@ typedef struct
 
 } LTDC_Layer_TypeDef;
 
-/** 
+/**
   * @brief Power Control
   */
 
@@ -1432,7 +1432,7 @@ typedef struct
   __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
-/** 
+/**
   * @brief Reset and Clock Control
   */
 
@@ -1475,7 +1475,7 @@ typedef struct
 
 } RCC_TypeDef;
 
-/** 
+/**
   * @brief Real-Time Clock
   */
 
@@ -1524,10 +1524,10 @@ typedef struct
 } RTC_TypeDef;
 
 
-/** 
+/**
   * @brief Serial Audio Interface
   */
-  
+
 typedef struct
 {
   __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
@@ -1545,7 +1545,7 @@ typedef struct
   __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
-/** 
+/**
   * @brief SD host Interface
   */
 
@@ -1573,7 +1573,7 @@ typedef struct
   __IO uint32_t FIFO;           /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
-/** 
+/**
   * @brief Serial Peripheral Interface
   */
 
@@ -1600,26 +1600,26 @@ typedef struct
 } SPI_TypeDef;
 
 #if defined(STM32F446xx)
-/** 
+/**
   * @brief SPDIFRX Interface
   */
 typedef struct
 {
   __IO uint32_t   CR;           /*!< Control register,                   Address offset: 0x00 */
   __IO uint16_t   IMR;          /*!< Interrupt mask register,            Address offset: 0x04 */
-  uint16_t        RESERVED0;    /*!< Reserved,  0x06                                          */  
+  uint16_t        RESERVED0;    /*!< Reserved,  0x06                                          */
   __IO uint32_t   SR;           /*!< Status register,                    Address offset: 0x08 */
   __IO uint16_t   IFCR;         /*!< Interrupt Flag Clear register,      Address offset: 0x0C */
-  uint16_t        RESERVED1;    /*!< Reserved,  0x0E                                          */   
+  uint16_t        RESERVED1;    /*!< Reserved,  0x0E                                          */
   __IO uint32_t   DR;           /*!< Data input register,                Address offset: 0x10 */
   __IO uint32_t   CSR;          /*!< Channel Status register,            Address offset: 0x14 */
    __IO uint32_t  DIR;          /*!< Debug Information register,         Address offset: 0x18 */
-  uint16_t        RESERVED2;    /*!< Reserved,  0x1A                                          */   
+  uint16_t        RESERVED2;    /*!< Reserved,  0x1A                                          */
 } SPDIFRX_TypeDef;
 #endif /* STM32F446xx */
 
 #if defined(STM32F446xx) || defined(STM32F469_479xx)
-/** 
+/**
   * @brief QUAD Serial Peripheral Interface
   */
 typedef struct
@@ -1634,32 +1634,32 @@ typedef struct
   __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
   __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
   __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */                  
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
   __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */    
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 #endif /* STM32F446xx || STM32F469_479xx */
 
 #if defined(STM32F446xx)
-/** 
+/**
   * @brief SPDIF-RX Interface
   */
 typedef struct
 {
   __IO uint32_t   CR;           /*!< Control register,                   Address offset: 0x00 */
   __IO uint16_t   IMR;          /*!< Interrupt mask register,            Address offset: 0x04 */
-  uint16_t        RESERVED0;    /*!< Reserved,  0x06                                          */  
+  uint16_t        RESERVED0;    /*!< Reserved,  0x06                                          */
   __IO uint32_t   SR;           /*!< Status register,                    Address offset: 0x08 */
   __IO uint16_t   IFCR;         /*!< Interrupt Flag Clear register,      Address offset: 0x0C */
-  uint16_t        RESERVED1;    /*!< Reserved,  0x0E                                          */   
+  uint16_t        RESERVED1;    /*!< Reserved,  0x0E                                          */
   __IO uint32_t   DR;           /*!< Data input register,                Address offset: 0x10 */
   __IO uint32_t   CSR;          /*!< Channel Status register,            Address offset: 0x14 */
    __IO uint32_t  DIR;          /*!< Debug Information register,         Address offset: 0x18 */
-  uint16_t        RESERVED2;    /*!< Reserved,  0x1A                                          */   
+  uint16_t        RESERVED2;    /*!< Reserved,  0x1A                                          */
 } SPDIF_TypeDef;
 #endif /* STM32F446xx */
 
-/** 
+/**
   * @brief TIM
   */
 
@@ -1703,10 +1703,10 @@ typedef struct
   uint16_t      RESERVED14;  /*!< Reserved, 0x52                                            */
 } TIM_TypeDef;
 
-/** 
+/**
   * @brief Universal Synchronous Asynchronous Receiver Transmitter
   */
- 
+
 typedef struct
 {
   __IO uint16_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
@@ -1725,7 +1725,7 @@ typedef struct
   uint16_t      RESERVED6;  /*!< Reserved, 0x1A                                                */
 } USART_TypeDef;
 
-/** 
+/**
   * @brief Window WATCHDOG
   */
 
@@ -1736,7 +1736,7 @@ typedef struct
   __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
-/** 
+/**
   * @brief Crypto Processor
   */
 
@@ -1780,11 +1780,11 @@ typedef struct
   __IO uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
 } CRYP_TypeDef;
 
-/** 
+/**
   * @brief HASH
   */
-  
-typedef struct 
+
+typedef struct
 {
   __IO uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
   __IO uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
@@ -1796,20 +1796,20 @@ typedef struct
   __IO uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
 } HASH_TypeDef;
 
-/** 
+/**
   * @brief HASH_DIGEST
   */
-  
-typedef struct 
+
+typedef struct
 {
-  __IO uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
+  __IO uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */
 } HASH_DIGEST_TypeDef;
 
-/** 
+/**
   * @brief RNG
   */
-  
-typedef struct 
+
+typedef struct
 {
   __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
   __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
@@ -1836,7 +1836,7 @@ typedef struct
 /**
   * @}
   */
-  
+
 /** @addtogroup Peripheral_memory_map
   * @{
   */
@@ -2027,7 +2027,7 @@ typedef struct
 /**
   * @}
   */
-  
+
 /** @addtogroup Peripheral_declaration
   * @{
   */
@@ -2084,7 +2084,7 @@ typedef struct
 #define ADC2                ((ADC_TypeDef *) ADC2_BASE)
 #define ADC3                ((ADC_TypeDef *) ADC3_BASE)
 #define SDIO                ((SDIO_TypeDef *) SDIO_BASE)
-#define SPI1                ((SPI_TypeDef *) SPI1_BASE) 
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
 #define SPI4                ((SPI_TypeDef *) SPI4_BASE)
 #define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
 #define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
@@ -2139,7 +2139,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
-#define ETH                 ((ETH_TypeDef *) ETH_BASE)  
+#define ETH                 ((ETH_TypeDef *) ETH_BASE)
 #define DMA2D               ((DMA2D_TypeDef *)DMA2D_BASE)
 #define DCMI                ((DCMI_TypeDef *) DCMI_BASE)
 #define CRYP                ((CRYP_TypeDef *) CRYP_BASE)
@@ -2173,11 +2173,11 @@ typedef struct
 /** @addtogroup Exported_constants
   * @{
   */
-  
+
   /** @addtogroup Peripheral_Registers_Bits_Definition
   * @{
   */
-    
+
 /******************************************************************************/
 /*                         Peripheral Registers_Bits_Definition               */
 /******************************************************************************/
@@ -2220,7 +2220,7 @@ typedef struct
 #define  ADC_CR1_RES_0                       ((uint32_t)0x01000000)        /*!<Bit 0 */
 #define  ADC_CR1_RES_1                       ((uint32_t)0x02000000)        /*!<Bit 1 */
 #define  ADC_CR1_OVRIE                       ((uint32_t)0x04000000)         /*!<overrun interrupt enable                              */
-  
+
 /*******************  Bit definition for ADC_CR2 register  ********************/
 #define  ADC_CR2_ADON                        ((uint32_t)0x00000001)        /*!<A/D Converter ON / OFF             */
 #define  ADC_CR2_CONT                        ((uint32_t)0x00000002)        /*!<Continuous Conversion              */
@@ -2453,7 +2453,7 @@ typedef struct
 #define  ADC_SQR3_SQ6_4                      ((uint32_t)0x20000000)        /*!<Bit 4 */
 
 /*******************  Bit definition for ADC_JSQR register  *******************/
-#define  ADC_JSQR_JSQ1                       ((uint32_t)0x0000001F)        /*!<JSQ1[4:0] bits (1st conversion in injected sequence) */  
+#define  ADC_JSQR_JSQ1                       ((uint32_t)0x0000001F)        /*!<JSQ1[4:0] bits (1st conversion in injected sequence) */
 #define  ADC_JSQR_JSQ1_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
 #define  ADC_JSQR_JSQ1_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
 #define  ADC_JSQR_JSQ1_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
@@ -2518,22 +2518,22 @@ typedef struct
 #define  ADC_CSR_DOVR3                       ((uint32_t)0x00200000)        /*!<ADC3 DMA overrun  flag */
 
 /*******************  Bit definition for ADC_CCR register  ********************/
-#define  ADC_CCR_MULTI                       ((uint32_t)0x0000001F)        /*!<MULTI[4:0] bits (Multi-ADC mode selection) */  
+#define  ADC_CCR_MULTI                       ((uint32_t)0x0000001F)        /*!<MULTI[4:0] bits (Multi-ADC mode selection) */
 #define  ADC_CCR_MULTI_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
 #define  ADC_CCR_MULTI_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
 #define  ADC_CCR_MULTI_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
 #define  ADC_CCR_MULTI_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
 #define  ADC_CCR_MULTI_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
-#define  ADC_CCR_DELAY                       ((uint32_t)0x00000F00)        /*!<DELAY[3:0] bits (Delay between 2 sampling phases) */  
+#define  ADC_CCR_DELAY                       ((uint32_t)0x00000F00)        /*!<DELAY[3:0] bits (Delay between 2 sampling phases) */
 #define  ADC_CCR_DELAY_0                     ((uint32_t)0x00000100)        /*!<Bit 0 */
 #define  ADC_CCR_DELAY_1                     ((uint32_t)0x00000200)        /*!<Bit 1 */
 #define  ADC_CCR_DELAY_2                     ((uint32_t)0x00000400)        /*!<Bit 2 */
 #define  ADC_CCR_DELAY_3                     ((uint32_t)0x00000800)        /*!<Bit 3 */
 #define  ADC_CCR_DDS                         ((uint32_t)0x00002000)        /*!<DMA disable selection (Multi-ADC mode) */
-#define  ADC_CCR_DMA                         ((uint32_t)0x0000C000)        /*!<DMA[1:0] bits (Direct Memory Access mode for multimode) */  
+#define  ADC_CCR_DMA                         ((uint32_t)0x0000C000)        /*!<DMA[1:0] bits (Direct Memory Access mode for multimode) */
 #define  ADC_CCR_DMA_0                       ((uint32_t)0x00004000)        /*!<Bit 0 */
 #define  ADC_CCR_DMA_1                       ((uint32_t)0x00008000)        /*!<Bit 1 */
-#define  ADC_CCR_ADCPRE                      ((uint32_t)0x00030000)        /*!<ADCPRE[1:0] bits (ADC prescaler) */  
+#define  ADC_CCR_ADCPRE                      ((uint32_t)0x00030000)        /*!<ADCPRE[1:0] bits (ADC prescaler) */
 #define  ADC_CCR_ADCPRE_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
 #define  ADC_CCR_ADCPRE_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
 #define  ADC_CCR_VBATE                       ((uint32_t)0x00400000)        /*!<VBAT Enable */
@@ -2704,7 +2704,7 @@ typedef struct
 #define  CAN_TI2R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended identifier */
 #define  CAN_TI2R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
 
-/*******************  Bit definition for CAN_TDT2R register  ******************/  
+/*******************  Bit definition for CAN_TDT2R register  ******************/
 #define  CAN_TDT2R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code */
 #define  CAN_TDT2R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time */
 #define  CAN_TDT2R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp */
@@ -3900,7 +3900,7 @@ typedef struct
 #define CRYP_CR_GCM_CCMPH                    ((uint32_t)0x00030000)
 #define CRYP_CR_GCM_CCMPH_0                  ((uint32_t)0x00010000)
 #define CRYP_CR_GCM_CCMPH_1                  ((uint32_t)0x00020000)
-#define CRYP_CR_ALGOMODE_3                   ((uint32_t)0x00080000) 
+#define CRYP_CR_ALGOMODE_3                   ((uint32_t)0x00080000)
 
 /****************** Bits definition for CRYP_SR register  *********************/
 #define CRYP_SR_IFEM                         ((uint32_t)0x00000001)
@@ -4077,11 +4077,11 @@ typedef struct
 /*                             DMA Controller                                 */
 /*                                                                            */
 /******************************************************************************/
-/********************  Bits definition for DMA_SxCR register  *****************/ 
+/********************  Bits definition for DMA_SxCR register  *****************/
 #define DMA_SxCR_CHSEL                       ((uint32_t)0x0E000000)
 #define DMA_SxCR_CHSEL_0                     ((uint32_t)0x02000000)
 #define DMA_SxCR_CHSEL_1                     ((uint32_t)0x04000000)
-#define DMA_SxCR_CHSEL_2                     ((uint32_t)0x08000000) 
+#define DMA_SxCR_CHSEL_2                     ((uint32_t)0x08000000)
 #define DMA_SxCR_MBURST                      ((uint32_t)0x01800000)
 #define DMA_SxCR_MBURST_0                    ((uint32_t)0x00800000)
 #define DMA_SxCR_MBURST_1                    ((uint32_t)0x01000000)
@@ -4089,7 +4089,7 @@ typedef struct
 #define DMA_SxCR_PBURST_0                    ((uint32_t)0x00200000)
 #define DMA_SxCR_PBURST_1                    ((uint32_t)0x00400000)
 #define DMA_SxCR_ACK                         ((uint32_t)0x00100000)
-#define DMA_SxCR_CT                          ((uint32_t)0x00080000)  
+#define DMA_SxCR_CT                          ((uint32_t)0x00080000)
 #define DMA_SxCR_DBM                         ((uint32_t)0x00040000)
 #define DMA_SxCR_PL                          ((uint32_t)0x00030000)
 #define DMA_SxCR_PL_0                        ((uint32_t)0x00010000)
@@ -4133,7 +4133,7 @@ typedef struct
 #define DMA_SxNDT_14                         ((uint32_t)0x00004000)
 #define DMA_SxNDT_15                         ((uint32_t)0x00008000)
 
-/********************  Bits definition for DMA_SxFCR register  ****************/ 
+/********************  Bits definition for DMA_SxFCR register  ****************/
 #define DMA_SxFCR_FEIE                       ((uint32_t)0x00000080)
 #define DMA_SxFCR_FS                         ((uint32_t)0x00000038)
 #define DMA_SxFCR_FS_0                       ((uint32_t)0x00000008)
@@ -4144,7 +4144,7 @@ typedef struct
 #define DMA_SxFCR_FTH_0                      ((uint32_t)0x00000001)
 #define DMA_SxFCR_FTH_1                      ((uint32_t)0x00000002)
 
-/********************  Bits definition for DMA_LISR register  *****************/ 
+/********************  Bits definition for DMA_LISR register  *****************/
 #define DMA_LISR_TCIF3                       ((uint32_t)0x08000000)
 #define DMA_LISR_HTIF3                       ((uint32_t)0x04000000)
 #define DMA_LISR_TEIF3                       ((uint32_t)0x02000000)
@@ -4166,7 +4166,7 @@ typedef struct
 #define DMA_LISR_DMEIF0                      ((uint32_t)0x00000004)
 #define DMA_LISR_FEIF0                       ((uint32_t)0x00000001)
 
-/********************  Bits definition for DMA_HISR register  *****************/ 
+/********************  Bits definition for DMA_HISR register  *****************/
 #define DMA_HISR_TCIF7                       ((uint32_t)0x08000000)
 #define DMA_HISR_HTIF7                       ((uint32_t)0x04000000)
 #define DMA_HISR_TEIF7                       ((uint32_t)0x02000000)
@@ -4188,7 +4188,7 @@ typedef struct
 #define DMA_HISR_DMEIF4                      ((uint32_t)0x00000004)
 #define DMA_HISR_FEIF4                       ((uint32_t)0x00000001)
 
-/********************  Bits definition for DMA_LIFCR register  ****************/ 
+/********************  Bits definition for DMA_LIFCR register  ****************/
 #define DMA_LIFCR_CTCIF3                     ((uint32_t)0x08000000)
 #define DMA_LIFCR_CHTIF3                     ((uint32_t)0x04000000)
 #define DMA_LIFCR_CTEIF3                     ((uint32_t)0x02000000)
@@ -4210,7 +4210,7 @@ typedef struct
 #define DMA_LIFCR_CDMEIF0                    ((uint32_t)0x00000004)
 #define DMA_LIFCR_CFEIF0                     ((uint32_t)0x00000001)
 
-/********************  Bits definition for DMA_HIFCR  register  ****************/ 
+/********************  Bits definition for DMA_HIFCR  register  ****************/
 #define DMA_HIFCR_CTCIF7                     ((uint32_t)0x08000000)
 #define DMA_HIFCR_CHTIF7                     ((uint32_t)0x04000000)
 #define DMA_HIFCR_CTEIF7                     ((uint32_t)0x02000000)
@@ -4298,7 +4298,7 @@ typedef struct
 
 #define DMA2D_FGCOLR_BLUE                  ((uint32_t)0x000000FF)               /*!< Blue Value */
 #define DMA2D_FGCOLR_GREEN                 ((uint32_t)0x0000FF00)               /*!< Green Value */
-#define DMA2D_FGCOLR_RED                   ((uint32_t)0x00FF0000)               /*!< Red Value */   
+#define DMA2D_FGCOLR_RED                   ((uint32_t)0x00FF0000)               /*!< Red Value */
 
 /********************  Bit definition for DMA2D_BGPFCCR register  *************/
 
@@ -4378,7 +4378,7 @@ typedef struct
 
 
 /********************  Bit definition for DMA2D_FGCLUT register  **************/
-                                                                     
+
 /********************  Bit definition for DMA2D_BGCLUT register  **************/
 
 
@@ -4619,9 +4619,9 @@ typedef struct
 #define FLASH_OPTCR_nWRP_10                 ((uint32_t)0x04000000)
 #define FLASH_OPTCR_nWRP_11                 ((uint32_t)0x08000000)
 
-#define FLASH_OPTCR_DB1M                    ((uint32_t)0x40000000) 
-#define FLASH_OPTCR_SPRMOD                  ((uint32_t)0x80000000) 
-                                             
+#define FLASH_OPTCR_DB1M                    ((uint32_t)0x40000000)
+#define FLASH_OPTCR_SPRMOD                  ((uint32_t)0x80000000)
+
 /******************  Bits definition for FLASH_OPTCR1 register  ***************/
 #define FLASH_OPTCR1_nWRP                    ((uint32_t)0x0FFF0000)
 #define FLASH_OPTCR1_nWRP_0                  ((uint32_t)0x00010000)
@@ -6303,7 +6303,7 @@ typedef struct
 #define  FMC_SDTR1_TMRD_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
 #define  FMC_SDTR1_TMRD_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
 #define  FMC_SDTR1_TMRD_3                   ((uint32_t)0x00000008)        /*!<Bit 3 */
-                                            
+
 #define  FMC_SDTR1_TXSR                     ((uint32_t)0x000000F0)        /*!<TXSR[3:0] bits (Exit self refresh) */
 #define  FMC_SDTR1_TXSR_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
 #define  FMC_SDTR1_TXSR_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
@@ -6342,7 +6342,7 @@ typedef struct
 #define  FMC_SDTR2_TMRD_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
 #define  FMC_SDTR2_TMRD_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
 #define  FMC_SDTR2_TMRD_3                   ((uint32_t)0x00000008)        /*!<Bit 3 */
-                                            
+
 #define  FMC_SDTR2_TXSR                     ((uint32_t)0x000000F0)        /*!<TXSR[3:0] bits (Exit self refresh) */
 #define  FMC_SDTR2_TXSR_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
 #define  FMC_SDTR2_TXSR_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
@@ -6380,7 +6380,7 @@ typedef struct
 #define  FMC_SDCMR_MODE_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
 #define  FMC_SDCMR_MODE_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
 #define  FMC_SDCMR_MODE_2                   ((uint32_t)0x00000003)        /*!<Bit 2 */
-                                            
+
 #define  FMC_SDCMR_CTB2                     ((uint32_t)0x00000008)        /*!<Command target 2 */
 
 #define  FMC_SDCMR_CTB1                     ((uint32_t)0x00000010)        /*!<Command target 1 */
@@ -7126,7 +7126,7 @@ typedef struct
 #define LTDC_LxDCCR_DCGREEN                 ((uint32_t)0x0000FF00)              /*!< Default Color Green */
 #define LTDC_LxDCCR_DCRED                   ((uint32_t)0x00FF0000)              /*!< Default Color Red */
 #define LTDC_LxDCCR_DCALPHA                 ((uint32_t)0xFF000000)              /*!< Default Color Alpha */
-                                
+
 /********************  Bit definition for LTDC_LxBFCR register  ***************/
 
 #define LTDC_LxBFCR_BF2                     ((uint32_t)0x00000007)              /*!< Blending Factor 2 */
@@ -7750,7 +7750,7 @@ typedef struct
 #define DSI_PCONFR_NL                  ((uint32_t)0x00000003)               /*!< Number of Lanes */
 #define DSI_PCONFR_NL0                 ((uint32_t)0x00000001)
 #define DSI_PCONFR_NL1                 ((uint32_t)0x00000002)
-                                     
+
 #define DSI_PCONFR_SW_TIME             ((uint32_t)0x0000FF00)               /*!< Stop Wait Time */
 #define DSI_PCONFR_SW_TIME0            ((uint32_t)0x00000100)
 #define DSI_PCONFR_SW_TIME1            ((uint32_t)0x00000200)
@@ -8123,7 +8123,7 @@ typedef struct
 #define DSI_WCFGR_COLMUX0                ((uint32_t)0x00000002)
 #define DSI_WCFGR_COLMUX1                ((uint32_t)0x00000004)
 #define DSI_WCFGR_COLMUX2                ((uint32_t)0x00000008)
- 
+
 #define DSI_WCFGR_TESRC                  ((uint32_t)0x00000010)              /*!< Tearing Effect Source */
 #define DSI_WCFGR_TEPOL                  ((uint32_t)0x00000020)              /*!< Tearing Effect Polarity */
 #define DSI_WCFGR_AR                     ((uint32_t)0x00000040)              /*!< Automatic Refresh */
@@ -8378,7 +8378,7 @@ typedef struct
 #define  PWR_CR_LPLVDS                       ((uint32_t)0x00000400)     /*!< Low-power regulator Low Voltage in Deep Sleep mode         */
 #define  PWR_CR_MRLVDS                       ((uint32_t)0x00000800)     /*!< Main regulator Low Voltage in Deep Sleep mode              */
 
-#define  PWR_CR_ADCDC1                       ((uint32_t)0x00002000)     /*!< Refer to AN4073 on how to use this bit */ 
+#define  PWR_CR_ADCDC1                       ((uint32_t)0x00002000)     /*!< Refer to AN4073 on how to use this bit */
 
 #define  PWR_CR_VOS                          ((uint32_t)0x0000C000)     /*!< VOS[1:0] bits (Regulator voltage scaling output selection) */
 #define  PWR_CR_VOS_0                        ((uint32_t)0x00004000)     /*!< Bit 0 */
@@ -8425,7 +8425,7 @@ typedef struct
 #define  QUADSPI_CR_TCEN                         ((uint32_t)0x00000008)            /*!< Timeout Counter Enable             */
 #define  QUADSPI_CR_SSHIFT                       ((uint32_t)0x00000030)            /*!< SSHIFT[1:0] Sample Shift           */
 #define  QUADSPI_CR_SSHIFT_0                     ((uint32_t)0x00000010)            /*!< Bit 0 */
-#define  QUADSPI_CR_SSHIFT_1                     ((uint32_t)0x00000020)            /*!< Bit 1 */  
+#define  QUADSPI_CR_SSHIFT_1                     ((uint32_t)0x00000020)            /*!< Bit 1 */
 #define  QUADSPI_CR_DFM                          ((uint32_t)0x00000040)            /*!< Dual Flash Mode                    */
 #define  QUADSPI_CR_FSEL                         ((uint32_t)0x00000080)            /*!< Flash Select                       */
 #define  QUADSPI_CR_FTHRES                       ((uint32_t)0x00000F00)            /*!< FTHRES[3:0] FIFO Level             */
@@ -8526,7 +8526,7 @@ typedef struct
 #define  QUADSPI_CCR_FMODE_1                      ((uint32_t)0x08000000)            /*!< Bit 1 */
 #define  QUADSPI_CCR_SIOO                         ((uint32_t)0x10000000)            /*!< SIOO: Send Instruction Only Once Mode */
 #define  QUADSPI_CCR_DHHC                         ((uint32_t)0x40000000)            /*!< DHHC: Delay Half Hclk Cycle */
-#define  QUADSPI_CCR_DDRM                         ((uint32_t)0x80000000)            /*!< DDRM: Double Data Rate Mode */ 
+#define  QUADSPI_CCR_DDRM                         ((uint32_t)0x80000000)            /*!< DDRM: Double Data Rate Mode */
 /******************  Bit definition for QUADSPI_AR register  *******************/
 #define  QUADSPI_AR_ADDRESS                       ((uint32_t)0xFFFFFFFF)            /*!< ADDRESS[31:0]: Address */
 
@@ -9171,7 +9171,7 @@ typedef struct
 #define  RCC_PLLSAICFGR_PLLSAIN_7            ((uint32_t)0x00002000)
 #define  RCC_PLLSAICFGR_PLLSAIN_8            ((uint32_t)0x00004000)
 
-#if defined(STM32F446xx) || defined(STM32F469_479xx)  
+#if defined(STM32F446xx) || defined(STM32F469_479xx)
 #define  RCC_PLLSAICFGR_PLLSAIP              ((uint32_t)0x00030000)
 #define  RCC_PLLSAICFGR_PLLSAIP_0            ((uint32_t)0x00010000)
 #define  RCC_PLLSAICFGR_PLLSAIP_1            ((uint32_t)0x00020000)
@@ -9755,7 +9755,7 @@ typedef struct
 #define  SAI_xSLOTR_FBOFF_2               ((uint32_t)0x00000004)        /*!<Bit 2 */
 #define  SAI_xSLOTR_FBOFF_3               ((uint32_t)0x00000008)        /*!<Bit 3 */
 #define  SAI_xSLOTR_FBOFF_4               ((uint32_t)0x00000010)        /*!<Bit 4 */
-                                     
+
 #define  SAI_xSLOTR_SLOTSZ                ((uint32_t)0x000000C0)        /*!<SLOTSZ[1:0] (Slot size)  */
 #define  SAI_xSLOTR_SLOTSZ_0              ((uint32_t)0x00000040)        /*!<Bit 0 */
 #define  SAI_xSLOTR_SLOTSZ_1              ((uint32_t)0x00000080)        /*!<Bit 1 */
@@ -9801,7 +9801,7 @@ typedef struct
 #define  SAI_xCLRFR_CLFSDET               ((uint32_t)0x00000040)        /*!<Clear Late frame synchronization detection           */
 
 /******************  Bit definition for SAI_xDR register  ******************/
-#define  SAI_xDR_DATA                     ((uint32_t)0xFFFFFFFF)        
+#define  SAI_xDR_DATA                     ((uint32_t)0xFFFFFFFF)
 
 #if defined(STM32F446xx)
 /******************************************************************************/
@@ -10127,7 +10127,7 @@ typedef struct
 /*                                 SYSCFG                                     */
 /*                                                                            */
 /******************************************************************************/
-/******************  Bit definition for SYSCFG_MEMRMP register  ***************/  
+/******************  Bit definition for SYSCFG_MEMRMP register  ***************/
 #define SYSCFG_MEMRMP_MEM_MODE          ((uint32_t)0x00000007) /*!< SYSCFG_Memory Remap Config */
 #define SYSCFG_MEMRMP_MEM_MODE_0        ((uint32_t)0x00000001) /*!<Bit 0 */
 #define SYSCFG_MEMRMP_MEM_MODE_1        ((uint32_t)0x00000002) /*!<Bit 1 */
@@ -10155,9 +10155,9 @@ typedef struct
 #define SYSCFG_EXTICR1_EXTI1            ((uint16_t)0x00F0) /*!<EXTI 1 configuration */
 #define SYSCFG_EXTICR1_EXTI2            ((uint16_t)0x0F00) /*!<EXTI 2 configuration */
 #define SYSCFG_EXTICR1_EXTI3            ((uint16_t)0xF000) /*!<EXTI 3 configuration */
-/** 
-  * @brief   EXTI0 configuration  
-  */ 
+/**
+  * @brief   EXTI0 configuration
+  */
 #define SYSCFG_EXTICR1_EXTI0_PA         ((uint16_t)0x0000) /*!<PA[0] pin */
 #define SYSCFG_EXTICR1_EXTI0_PB         ((uint16_t)0x0001) /*!<PB[0] pin */
 #define SYSCFG_EXTICR1_EXTI0_PC         ((uint16_t)0x0002) /*!<PC[0] pin */
@@ -10170,9 +10170,9 @@ typedef struct
 #define SYSCFG_EXTICR1_EXTI0_PJ         ((uint16_t)0x0009) /*!<PJ[0] pin */
 #define SYSCFG_EXTICR1_EXTI0_PK         ((uint16_t)0x000A) /*!<PK[0] pin */
 
-/** 
-  * @brief   EXTI1 configuration  
-  */ 
+/**
+  * @brief   EXTI1 configuration
+  */
 #define SYSCFG_EXTICR1_EXTI1_PA         ((uint16_t)0x0000) /*!<PA[1] pin */
 #define SYSCFG_EXTICR1_EXTI1_PB         ((uint16_t)0x0010) /*!<PB[1] pin */
 #define SYSCFG_EXTICR1_EXTI1_PC         ((uint16_t)0x0020) /*!<PC[1] pin */
@@ -10185,9 +10185,9 @@ typedef struct
 #define SYSCFG_EXTICR1_EXTI1_PJ         ((uint16_t)0x0090) /*!<PJ[1] pin */
 #define SYSCFG_EXTICR1_EXTI1_PK         ((uint16_t)0x00A0) /*!<PK[1] pin */
 
-/** 
-  * @brief   EXTI2 configuration  
-  */ 
+/**
+  * @brief   EXTI2 configuration
+  */
 #define SYSCFG_EXTICR1_EXTI2_PA         ((uint16_t)0x0000) /*!<PA[2] pin */
 #define SYSCFG_EXTICR1_EXTI2_PB         ((uint16_t)0x0100) /*!<PB[2] pin */
 #define SYSCFG_EXTICR1_EXTI2_PC         ((uint16_t)0x0200) /*!<PC[2] pin */
@@ -10200,9 +10200,9 @@ typedef struct
 #define SYSCFG_EXTICR1_EXTI2_PJ         ((uint16_t)0x0900) /*!<PJ[2] pin */
 #define SYSCFG_EXTICR1_EXTI2_PK         ((uint16_t)0x0A00) /*!<PK[2] pin */
 
-/** 
-  * @brief   EXTI3 configuration  
-  */ 
+/**
+  * @brief   EXTI3 configuration
+  */
 #define SYSCFG_EXTICR1_EXTI3_PA         ((uint16_t)0x0000) /*!<PA[3] pin */
 #define SYSCFG_EXTICR1_EXTI3_PB         ((uint16_t)0x1000) /*!<PB[3] pin */
 #define SYSCFG_EXTICR1_EXTI3_PC         ((uint16_t)0x2000) /*!<PC[3] pin */
@@ -10220,9 +10220,9 @@ typedef struct
 #define SYSCFG_EXTICR2_EXTI5            ((uint16_t)0x00F0) /*!<EXTI 5 configuration */
 #define SYSCFG_EXTICR2_EXTI6            ((uint16_t)0x0F00) /*!<EXTI 6 configuration */
 #define SYSCFG_EXTICR2_EXTI7            ((uint16_t)0xF000) /*!<EXTI 7 configuration */
-/** 
-  * @brief   EXTI4 configuration  
-  */ 
+/**
+  * @brief   EXTI4 configuration
+  */
 #define SYSCFG_EXTICR2_EXTI4_PA         ((uint16_t)0x0000) /*!<PA[4] pin */
 #define SYSCFG_EXTICR2_EXTI4_PB         ((uint16_t)0x0001) /*!<PB[4] pin */
 #define SYSCFG_EXTICR2_EXTI4_PC         ((uint16_t)0x0002) /*!<PC[4] pin */
@@ -10235,9 +10235,9 @@ typedef struct
 #define SYSCFG_EXTICR2_EXTI4_PJ         ((uint16_t)0x0009) /*!<PJ[4] pin */
 #define SYSCFG_EXTICR2_EXTI4_PK         ((uint16_t)0x000A) /*!<PK[4] pin */
 
-/** 
-  * @brief   EXTI5 configuration  
-  */ 
+/**
+  * @brief   EXTI5 configuration
+  */
 #define SYSCFG_EXTICR2_EXTI5_PA         ((uint16_t)0x0000) /*!<PA[5] pin */
 #define SYSCFG_EXTICR2_EXTI5_PB         ((uint16_t)0x0010) /*!<PB[5] pin */
 #define SYSCFG_EXTICR2_EXTI5_PC         ((uint16_t)0x0020) /*!<PC[5] pin */
@@ -10250,9 +10250,9 @@ typedef struct
 #define SYSCFG_EXTICR2_EXTI5_PJ         ((uint16_t)0x0090) /*!<PJ[5] pin */
 #define SYSCFG_EXTICR2_EXTI5_PK         ((uint16_t)0x00A0) /*!<PK[5] pin */
 
-/** 
-  * @brief   EXTI6 configuration  
-  */ 
+/**
+  * @brief   EXTI6 configuration
+  */
 #define SYSCFG_EXTICR2_EXTI6_PA         ((uint16_t)0x0000) /*!<PA[6] pin */
 #define SYSCFG_EXTICR2_EXTI6_PB         ((uint16_t)0x0100) /*!<PB[6] pin */
 #define SYSCFG_EXTICR2_EXTI6_PC         ((uint16_t)0x0200) /*!<PC[6] pin */
@@ -10265,9 +10265,9 @@ typedef struct
 #define SYSCFG_EXTICR2_EXTI6_PJ         ((uint16_t)0x0900) /*!<PJ[6] pin */
 #define SYSCFG_EXTICR2_EXTI6_PK         ((uint16_t)0x0A00) /*!<PK[6] pin */
 
-/** 
-  * @brief   EXTI7 configuration  
-  */ 
+/**
+  * @brief   EXTI7 configuration
+  */
 #define SYSCFG_EXTICR2_EXTI7_PA         ((uint16_t)0x0000) /*!<PA[7] pin */
 #define SYSCFG_EXTICR2_EXTI7_PB         ((uint16_t)0x1000) /*!<PB[7] pin */
 #define SYSCFG_EXTICR2_EXTI7_PC         ((uint16_t)0x2000) /*!<PC[7] pin */
@@ -10285,10 +10285,10 @@ typedef struct
 #define SYSCFG_EXTICR3_EXTI9            ((uint16_t)0x00F0) /*!<EXTI 9 configuration */
 #define SYSCFG_EXTICR3_EXTI10           ((uint16_t)0x0F00) /*!<EXTI 10 configuration */
 #define SYSCFG_EXTICR3_EXTI11           ((uint16_t)0xF000) /*!<EXTI 11 configuration */
-           
-/** 
-  * @brief   EXTI8 configuration  
-  */ 
+
+/**
+  * @brief   EXTI8 configuration
+  */
 #define SYSCFG_EXTICR3_EXTI8_PA         ((uint16_t)0x0000) /*!<PA[8] pin */
 #define SYSCFG_EXTICR3_EXTI8_PB         ((uint16_t)0x0001) /*!<PB[8] pin */
 #define SYSCFG_EXTICR3_EXTI8_PC         ((uint16_t)0x0002) /*!<PC[8] pin */
@@ -10300,9 +10300,9 @@ typedef struct
 #define SYSCFG_EXTICR3_EXTI8_PI         ((uint16_t)0x0008) /*!<PI[8] pin */
 #define SYSCFG_EXTICR3_EXTI8_PJ         ((uint16_t)0x0009) /*!<PJ[8] pin */
 
-/** 
-  * @brief   EXTI9 configuration  
-  */ 
+/**
+  * @brief   EXTI9 configuration
+  */
 #define SYSCFG_EXTICR3_EXTI9_PA         ((uint16_t)0x0000) /*!<PA[9] pin */
 #define SYSCFG_EXTICR3_EXTI9_PB         ((uint16_t)0x0010) /*!<PB[9] pin */
 #define SYSCFG_EXTICR3_EXTI9_PC         ((uint16_t)0x0020) /*!<PC[9] pin */
@@ -10314,9 +10314,9 @@ typedef struct
 #define SYSCFG_EXTICR3_EXTI9_PI         ((uint16_t)0x0080) /*!<PI[9] pin */
 #define SYSCFG_EXTICR3_EXTI9_PJ         ((uint16_t)0x0090) /*!<PJ[9] pin */
 
-/** 
-  * @brief   EXTI10 configuration  
-  */ 
+/**
+  * @brief   EXTI10 configuration
+  */
 #define SYSCFG_EXTICR3_EXTI10_PA        ((uint16_t)0x0000) /*!<PA[10] pin */
 #define SYSCFG_EXTICR3_EXTI10_PB        ((uint16_t)0x0100) /*!<PB[10] pin */
 #define SYSCFG_EXTICR3_EXTI10_PC        ((uint16_t)0x0200) /*!<PC[10] pin */
@@ -10328,9 +10328,9 @@ typedef struct
 #define SYSCFG_EXTICR3_EXTI10_PI        ((uint16_t)0x0800) /*!<PI[10] pin */
 #define SYSCFG_EXTICR3_EXTI10_PJ        ((uint16_t)0x0900) /*!<PJ[10] pin */
 
-/** 
-  * @brief   EXTI11 configuration  
-  */ 
+/**
+  * @brief   EXTI11 configuration
+  */
 #define SYSCFG_EXTICR3_EXTI11_PA        ((uint16_t)0x0000) /*!<PA[11] pin */
 #define SYSCFG_EXTICR3_EXTI11_PB        ((uint16_t)0x1000) /*!<PB[11] pin */
 #define SYSCFG_EXTICR3_EXTI11_PC        ((uint16_t)0x2000) /*!<PC[11] pin */
@@ -10347,9 +10347,9 @@ typedef struct
 #define SYSCFG_EXTICR4_EXTI13           ((uint16_t)0x00F0) /*!<EXTI 13 configuration */
 #define SYSCFG_EXTICR4_EXTI14           ((uint16_t)0x0F00) /*!<EXTI 14 configuration */
 #define SYSCFG_EXTICR4_EXTI15           ((uint16_t)0xF000) /*!<EXTI 15 configuration */
-/** 
-  * @brief   EXTI12 configuration  
-  */ 
+/**
+  * @brief   EXTI12 configuration
+  */
 #define SYSCFG_EXTICR4_EXTI12_PA        ((uint16_t)0x0000) /*!<PA[12] pin */
 #define SYSCFG_EXTICR4_EXTI12_PB        ((uint16_t)0x0001) /*!<PB[12] pin */
 #define SYSCFG_EXTICR4_EXTI12_PC        ((uint16_t)0x0002) /*!<PC[12] pin */
@@ -10361,9 +10361,9 @@ typedef struct
 #define SYSCFG_EXTICR4_EXTI12_PI        ((uint16_t)0x0008) /*!<PI[12] pin */
 #define SYSCFG_EXTICR4_EXTI12_PJ        ((uint16_t)0x0009) /*!<PJ[12] pin */
 
-/** 
-  * @brief   EXTI13 configuration  
-  */ 
+/**
+  * @brief   EXTI13 configuration
+  */
 #define SYSCFG_EXTICR4_EXTI13_PA        ((uint16_t)0x0000) /*!<PA[13] pin */
 #define SYSCFG_EXTICR4_EXTI13_PB        ((uint16_t)0x0010) /*!<PB[13] pin */
 #define SYSCFG_EXTICR4_EXTI13_PC        ((uint16_t)0x0020) /*!<PC[13] pin */
@@ -10375,9 +10375,9 @@ typedef struct
 #define SYSCFG_EXTICR4_EXTI13_PI        ((uint16_t)0x0008) /*!<PI[13] pin */
 #define SYSCFG_EXTICR4_EXTI13_PJ        ((uint16_t)0x0009) /*!<PJ[13] pin */
 
-/** 
-  * @brief   EXTI14 configuration  
-  */ 
+/**
+  * @brief   EXTI14 configuration
+  */
 #define SYSCFG_EXTICR4_EXTI14_PA        ((uint16_t)0x0000) /*!<PA[14] pin */
 #define SYSCFG_EXTICR4_EXTI14_PB        ((uint16_t)0x0100) /*!<PB[14] pin */
 #define SYSCFG_EXTICR4_EXTI14_PC        ((uint16_t)0x0200) /*!<PC[14] pin */
@@ -10389,9 +10389,9 @@ typedef struct
 #define SYSCFG_EXTICR4_EXTI14_PI        ((uint16_t)0x0800) /*!<PI[14] pin */
 #define SYSCFG_EXTICR4_EXTI14_PJ        ((uint16_t)0x0900) /*!<PJ[14] pin */
 
-/** 
-  * @brief   EXTI15 configuration  
-  */ 
+/**
+  * @brief   EXTI15 configuration
+  */
 #define SYSCFG_EXTICR4_EXTI15_PA        ((uint16_t)0x0000) /*!<PA[15] pin */
 #define SYSCFG_EXTICR4_EXTI15_PB        ((uint16_t)0x1000) /*!<PB[15] pin */
 #define SYSCFG_EXTICR4_EXTI15_PC        ((uint16_t)0x2000) /*!<PC[15] pin */
@@ -10408,7 +10408,7 @@ typedef struct
 #define SYSCFG_CFGR2_CLL                ((uint32_t)0x00000001) /*!< Core Lockup Lock */
 #define SYSCFG_CFGR2_PVDL               ((uint32_t)0x00000004) /*!<  PVD Lock */
 #endif /* STM32F410xx */
-/******************  Bit definition for SYSCFG_CMPCR register  ****************/  
+/******************  Bit definition for SYSCFG_CMPCR register  ****************/
 #define SYSCFG_CMPCR_CMP_PD             ((uint32_t)0x00000001) /*!<Compensation cell ready flag */
 #define SYSCFG_CMPCR_READY              ((uint32_t)0x00000100) /*!<Compensation cell power-down */
 
@@ -10777,8 +10777,8 @@ typedef struct
 #define  LPTIM_CFGR_WAVE                        ((uint32_t)0x00100000)             /*!< Waveform shape          */
 #define  LPTIM_CFGR_WAVPOL                      ((uint32_t)0x00200000)             /*!< Waveform shape polarity */
 #define  LPTIM_CFGR_PRELOAD                     ((uint32_t)0x00400000)             /*!< Reg update mode         */
-#define  LPTIM_CFGR_COUNTMODE                   ((uint32_t)0x00800000)             /*!< Counter mode enable     */     
-#define  LPTIM_CFGR_ENC                         ((uint32_t)0x01000000)             /*!< Encoder mode enable     */          
+#define  LPTIM_CFGR_COUNTMODE                   ((uint32_t)0x00800000)             /*!< Counter mode enable     */
+#define  LPTIM_CFGR_ENC                         ((uint32_t)0x01000000)             /*!< Encoder mode enable     */
 
 /******************  Bit definition for LPTIM_CR register  ********************/
 #define  LPTIM_CR_ENABLE                        ((uint32_t)0x00000001)             /*!< LPTIMer enable                 */
@@ -10980,10 +10980,10 @@ typedef struct
   #define ETH_MACCR_IFG_88Bit     ((uint32_t)0x00020000)  /* Minimum IFG between frames during transmission is 88Bit */
   #define ETH_MACCR_IFG_80Bit     ((uint32_t)0x00040000)  /* Minimum IFG between frames during transmission is 80Bit */
   #define ETH_MACCR_IFG_72Bit     ((uint32_t)0x00060000)  /* Minimum IFG between frames during transmission is 72Bit */
-  #define ETH_MACCR_IFG_64Bit     ((uint32_t)0x00080000)  /* Minimum IFG between frames during transmission is 64Bit */        
+  #define ETH_MACCR_IFG_64Bit     ((uint32_t)0x00080000)  /* Minimum IFG between frames during transmission is 64Bit */
   #define ETH_MACCR_IFG_56Bit     ((uint32_t)0x000A0000)  /* Minimum IFG between frames during transmission is 56Bit */
   #define ETH_MACCR_IFG_48Bit     ((uint32_t)0x000C0000)  /* Minimum IFG between frames during transmission is 48Bit */
-  #define ETH_MACCR_IFG_40Bit     ((uint32_t)0x000E0000)  /* Minimum IFG between frames during transmission is 40Bit */              
+  #define ETH_MACCR_IFG_40Bit     ((uint32_t)0x000E0000)  /* Minimum IFG between frames during transmission is 40Bit */
 #define ETH_MACCR_CSD     ((uint32_t)0x00010000)  /* Carrier sense disable (during transmission) */
 #define ETH_MACCR_FES     ((uint32_t)0x00004000)  /* Fast ethernet speed */
 #define ETH_MACCR_ROD     ((uint32_t)0x00002000)  /* Receive own disable */
@@ -10997,24 +10997,24 @@ typedef struct
   #define ETH_MACCR_BL_10    ((uint32_t)0x00000000)  /* k = min (n, 10) */
   #define ETH_MACCR_BL_8     ((uint32_t)0x00000020)  /* k = min (n, 8) */
   #define ETH_MACCR_BL_4     ((uint32_t)0x00000040)  /* k = min (n, 4) */
-  #define ETH_MACCR_BL_1     ((uint32_t)0x00000060)  /* k = min (n, 1) */ 
+  #define ETH_MACCR_BL_1     ((uint32_t)0x00000060)  /* k = min (n, 1) */
 #define ETH_MACCR_DC      ((uint32_t)0x00000010)  /* Defferal check */
 #define ETH_MACCR_TE      ((uint32_t)0x00000008)  /* Transmitter enable */
 #define ETH_MACCR_RE      ((uint32_t)0x00000004)  /* Receiver enable */
 
 /* Bit definition for Ethernet MAC Frame Filter Register */
-#define ETH_MACFFR_RA     ((uint32_t)0x80000000)  /* Receive all */ 
-#define ETH_MACFFR_HPF    ((uint32_t)0x00000400)  /* Hash or perfect filter */ 
-#define ETH_MACFFR_SAF    ((uint32_t)0x00000200)  /* Source address filter enable */ 
-#define ETH_MACFFR_SAIF   ((uint32_t)0x00000100)  /* SA inverse filtering */ 
+#define ETH_MACFFR_RA     ((uint32_t)0x80000000)  /* Receive all */
+#define ETH_MACFFR_HPF    ((uint32_t)0x00000400)  /* Hash or perfect filter */
+#define ETH_MACFFR_SAF    ((uint32_t)0x00000200)  /* Source address filter enable */
+#define ETH_MACFFR_SAIF   ((uint32_t)0x00000100)  /* SA inverse filtering */
 #define ETH_MACFFR_PCF    ((uint32_t)0x000000C0)  /* Pass control frames: 3 cases */
   #define ETH_MACFFR_PCF_BlockAll                ((uint32_t)0x00000040)  /* MAC filters all control frames from reaching the application */
   #define ETH_MACFFR_PCF_ForwardAll              ((uint32_t)0x00000080)  /* MAC forwards all control frames to application even if they fail the Address Filter */
-  #define ETH_MACFFR_PCF_ForwardPassedAddrFilter ((uint32_t)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */ 
-#define ETH_MACFFR_BFD    ((uint32_t)0x00000020)  /* Broadcast frame disable */ 
-#define ETH_MACFFR_PAM    ((uint32_t)0x00000010)  /* Pass all mutlicast */ 
-#define ETH_MACFFR_DAIF   ((uint32_t)0x00000008)  /* DA Inverse filtering */ 
-#define ETH_MACFFR_HM     ((uint32_t)0x00000004)  /* Hash multicast */ 
+  #define ETH_MACFFR_PCF_ForwardPassedAddrFilter ((uint32_t)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */
+#define ETH_MACFFR_BFD    ((uint32_t)0x00000020)  /* Broadcast frame disable */
+#define ETH_MACFFR_PAM    ((uint32_t)0x00000010)  /* Pass all mutlicast */
+#define ETH_MACFFR_DAIF   ((uint32_t)0x00000008)  /* DA Inverse filtering */
+#define ETH_MACFFR_HM     ((uint32_t)0x00000004)  /* Hash multicast */
 #define ETH_MACFFR_HU     ((uint32_t)0x00000002)  /* Hash unicast */
 #define ETH_MACFFR_PM     ((uint32_t)0x00000001)  /* Promiscuous mode */
 
@@ -11025,17 +11025,17 @@ typedef struct
 #define ETH_MACHTLR_HTL   ((uint32_t)0xFFFFFFFF)  /* Hash table low */
 
 /* Bit definition for Ethernet MAC MII Address Register */
-#define ETH_MACMIIAR_PA   ((uint32_t)0x0000F800)  /* Physical layer address */ 
-#define ETH_MACMIIAR_MR   ((uint32_t)0x000007C0)  /* MII register in the selected PHY */ 
-#define ETH_MACMIIAR_CR   ((uint32_t)0x0000001C)  /* CR clock range: 6 cases */ 
+#define ETH_MACMIIAR_PA   ((uint32_t)0x0000F800)  /* Physical layer address */
+#define ETH_MACMIIAR_MR   ((uint32_t)0x000007C0)  /* MII register in the selected PHY */
+#define ETH_MACMIIAR_CR   ((uint32_t)0x0000001C)  /* CR clock range: 6 cases */
   #define ETH_MACMIIAR_CR_Div42   ((uint32_t)0x00000000)  /* HCLK:60-100 MHz; MDC clock= HCLK/42 */
   #define ETH_MACMIIAR_CR_Div62   ((uint32_t)0x00000004)  /* HCLK:100-150 MHz; MDC clock= HCLK/62 */
   #define ETH_MACMIIAR_CR_Div16   ((uint32_t)0x00000008)  /* HCLK:20-35 MHz; MDC clock= HCLK/16 */
   #define ETH_MACMIIAR_CR_Div26   ((uint32_t)0x0000000C)  /* HCLK:35-60 MHz; MDC clock= HCLK/26 */
-  #define ETH_MACMIIAR_CR_Div102  ((uint32_t)0x00000010)  /* HCLK:150-168 MHz; MDC clock= HCLK/102 */  
-#define ETH_MACMIIAR_MW   ((uint32_t)0x00000002)  /* MII write */ 
-#define ETH_MACMIIAR_MB   ((uint32_t)0x00000001)  /* MII busy */ 
-  
+  #define ETH_MACMIIAR_CR_Div102  ((uint32_t)0x00000010)  /* HCLK:150-168 MHz; MDC clock= HCLK/102 */
+#define ETH_MACMIIAR_MW   ((uint32_t)0x00000002)  /* MII write */
+#define ETH_MACMIIAR_MB   ((uint32_t)0x00000001)  /* MII busy */
+
 /* Bit definition for Ethernet MAC MII Data Register */
 #define ETH_MACMIIDR_MD   ((uint32_t)0x0000FFFF)  /* MII data: read/write data from/to PHY */
 
@@ -11046,7 +11046,7 @@ typedef struct
   #define ETH_MACFCR_PLT_Minus4   ((uint32_t)0x00000000)  /* Pause time minus 4 slot times */
   #define ETH_MACFCR_PLT_Minus28  ((uint32_t)0x00000010)  /* Pause time minus 28 slot times */
   #define ETH_MACFCR_PLT_Minus144 ((uint32_t)0x00000020)  /* Pause time minus 144 slot times */
-  #define ETH_MACFCR_PLT_Minus256 ((uint32_t)0x00000030)  /* Pause time minus 256 slot times */      
+  #define ETH_MACFCR_PLT_Minus256 ((uint32_t)0x00000030)  /* Pause time minus 256 slot times */
 #define ETH_MACFCR_UPFD   ((uint32_t)0x00000008)  /* Unicast pause frame detect */
 #define ETH_MACFCR_RFCE   ((uint32_t)0x00000004)  /* Receive flow control enable */
 #define ETH_MACFCR_TFCE   ((uint32_t)0x00000002)  /* Transmit flow control enable */
@@ -11056,7 +11056,7 @@ typedef struct
 #define ETH_MACVLANTR_VLANTC ((uint32_t)0x00010000)  /* 12-bit VLAN tag comparison */
 #define ETH_MACVLANTR_VLANTI ((uint32_t)0x0000FFFF)  /* VLAN tag identifier (for receive frames) */
 
-/* Bit definition for Ethernet MAC Remote Wake-UpFrame Filter Register */ 
+/* Bit definition for Ethernet MAC Remote Wake-UpFrame Filter Register */
 #define ETH_MACRWUFFR_D   ((uint32_t)0xFFFFFFFF)  /* Wake-up frame filter register data */
 /* Eight sequential Writes to this address (offset 0x28) will write all Wake-UpFrame Filter Registers.
    Eight sequential Reads from this address (offset 0x28) will read all Wake-UpFrame Filter Registers. */
@@ -11064,13 +11064,13 @@ typedef struct
    Wake-UpFrame Filter Reg1 : Filter 1 Byte Mask
    Wake-UpFrame Filter Reg2 : Filter 2 Byte Mask
    Wake-UpFrame Filter Reg3 : Filter 3 Byte Mask
-   Wake-UpFrame Filter Reg4 : RSVD - Filter3 Command - RSVD - Filter2 Command - 
+   Wake-UpFrame Filter Reg4 : RSVD - Filter3 Command - RSVD - Filter2 Command -
                               RSVD - Filter1 Command - RSVD - Filter0 Command
    Wake-UpFrame Filter Re5 : Filter3 Offset - Filter2 Offset - Filter1 Offset - Filter0 Offset
    Wake-UpFrame Filter Re6 : Filter1 CRC16 - Filter0 CRC16
    Wake-UpFrame Filter Re7 : Filter3 CRC16 - Filter2 CRC16 */
 
-/* Bit definition for Ethernet MAC PMT Control and Status Register */ 
+/* Bit definition for Ethernet MAC PMT Control and Status Register */
 #define ETH_MACPMTCSR_WFFRPR ((uint32_t)0x80000000)  /* Wake-Up Frame Filter Register Pointer Reset */
 #define ETH_MACPMTCSR_GU     ((uint32_t)0x00000200)  /* Global Unicast */
 #define ETH_MACPMTCSR_WFR    ((uint32_t)0x00000040)  /* Wake-Up Frame Received */
@@ -11105,7 +11105,7 @@ typedef struct
   #define ETH_MACA1HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
   #define ETH_MACA1HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
   #define ETH_MACA1HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
-  #define ETH_MACA1HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [7:0] */ 
+  #define ETH_MACA1HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [7:0] */
 #define ETH_MACA1HR_MACA1H   ((uint32_t)0x0000FFFF)  /* MAC address1 high */
 
 /* Bit definition for Ethernet MAC Address1 Low Register */
@@ -11257,26 +11257,26 @@ typedef struct
   #define ETH_DMABMR_RDP_4Beat    ((uint32_t)0x00080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
   #define ETH_DMABMR_RDP_8Beat    ((uint32_t)0x00100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
   #define ETH_DMABMR_RDP_16Beat   ((uint32_t)0x00200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
-  #define ETH_DMABMR_RDP_32Beat   ((uint32_t)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */                
+  #define ETH_DMABMR_RDP_32Beat   ((uint32_t)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
   #define ETH_DMABMR_RDP_4xPBL_4Beat   ((uint32_t)0x01020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
   #define ETH_DMABMR_RDP_4xPBL_8Beat   ((uint32_t)0x01040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
   #define ETH_DMABMR_RDP_4xPBL_16Beat  ((uint32_t)0x01080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
   #define ETH_DMABMR_RDP_4xPBL_32Beat  ((uint32_t)0x01100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
   #define ETH_DMABMR_RDP_4xPBL_64Beat  ((uint32_t)0x01200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 64 */
-  #define ETH_DMABMR_RDP_4xPBL_128Beat ((uint32_t)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */  
+  #define ETH_DMABMR_RDP_4xPBL_128Beat ((uint32_t)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */
 #define ETH_DMABMR_FB        ((uint32_t)0x00010000)  /* Fixed Burst */
 #define ETH_DMABMR_RTPR      ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
   #define ETH_DMABMR_RTPR_1_1     ((uint32_t)0x00000000)  /* Rx Tx priority ratio */
   #define ETH_DMABMR_RTPR_2_1     ((uint32_t)0x00004000)  /* Rx Tx priority ratio */
   #define ETH_DMABMR_RTPR_3_1     ((uint32_t)0x00008000)  /* Rx Tx priority ratio */
-  #define ETH_DMABMR_RTPR_4_1     ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */  
+  #define ETH_DMABMR_RTPR_4_1     ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
 #define ETH_DMABMR_PBL    ((uint32_t)0x00003F00)  /* Programmable burst length */
   #define ETH_DMABMR_PBL_1Beat    ((uint32_t)0x00000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
   #define ETH_DMABMR_PBL_2Beat    ((uint32_t)0x00000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
   #define ETH_DMABMR_PBL_4Beat    ((uint32_t)0x00000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
   #define ETH_DMABMR_PBL_8Beat    ((uint32_t)0x00000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
   #define ETH_DMABMR_PBL_16Beat   ((uint32_t)0x00001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-  #define ETH_DMABMR_PBL_32Beat   ((uint32_t)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */                
+  #define ETH_DMABMR_PBL_32Beat   ((uint32_t)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
   #define ETH_DMABMR_PBL_4xPBL_4Beat   ((uint32_t)0x01000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
   #define ETH_DMABMR_PBL_4xPBL_8Beat   ((uint32_t)0x01000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
   #define ETH_DMABMR_PBL_4xPBL_16Beat  ((uint32_t)0x01000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
@@ -11322,7 +11322,7 @@ typedef struct
   #define ETH_DMASR_RPS_Waiting         ((uint32_t)0x00060000)  /* Running - waiting for packet */
   #define ETH_DMASR_RPS_Suspended       ((uint32_t)0x00080000)  /* Suspended - Rx Descriptor unavailable */
   #define ETH_DMASR_RPS_Closing         ((uint32_t)0x000A0000)  /* Running - closing descriptor */
-  #define ETH_DMASR_RPS_Queuing         ((uint32_t)0x000E0000)  /* Running - queuing the recieve frame into host memory */
+  #define ETH_DMASR_RPS_Queuing         ((uint32_t)0x000E0000)  /* Running - queuing the receive frame into host memory */
 #define ETH_DMASR_NIS        ((uint32_t)0x00010000)  /* Normal interrupt summary */
 #define ETH_DMASR_AIS        ((uint32_t)0x00008000)  /* Abnormal interrupt summary */
 #define ETH_DMASR_ERS        ((uint32_t)0x00004000)  /* Early receive status */
@@ -11406,7 +11406,7 @@ typedef struct
 
  /**
   * @}
-  */ 
+  */
 
 #ifdef USE_STDPERIPH_DRIVER
   #include "stm32f4xx_conf.h"

--- a/lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_can.c
+++ b/lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_can.c
@@ -4,63 +4,63 @@
   * @author  MCD Application Team
   * @version V1.1.0
   * @date    11-January-2013
-  * @brief   This file provides firmware functions to manage the following 
-  *          functionalities of the Controller area network (CAN) peripheral:           
-  *           + Initialization and Configuration 
-  *           + CAN Frames Transmission 
-  *           + CAN Frames Reception    
-  *           + Operation modes switch  
-  *           + Error management          
-  *           + Interrupts and flags        
-  *         
-@verbatim                                 
- ===============================================================================      
+  * @brief   This file provides firmware functions to manage the following
+  *          functionalities of the Controller area network (CAN) peripheral:
+  *           + Initialization and Configuration
+  *           + CAN Frames Transmission
+  *           + CAN Frames Reception
+  *           + Operation modes switch
+  *           + Error management
+  *           + Interrupts and flags
+  *
+@verbatim
+ ===============================================================================
                         ##### How to use this driver #####
  ===============================================================================
-    [..]            
-      (#) Enable the CAN controller interface clock using 
-          RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN1, ENABLE); for CAN1 
+    [..]
+      (#) Enable the CAN controller interface clock using
+          RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN1, ENABLE); for CAN1
           and RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN2, ENABLE); for CAN2
       -@- In case you are using CAN2 only, you have to enable the CAN1 clock.
-       
+
       (#) CAN pins configuration
         (++) Enable the clock for the CAN GPIOs using the following function:
-             RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOx, ENABLE);   
-        (++) Connect the involved CAN pins to AF9 using the following function 
-             GPIO_PinAFConfig(GPIOx, GPIO_PinSourcex, GPIO_AF_CANx); 
+             RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOx, ENABLE);
+        (++) Connect the involved CAN pins to AF9 using the following function
+             GPIO_PinAFConfig(GPIOx, GPIO_PinSourcex, GPIO_AF_CANx);
         (++) Configure these CAN pins in alternate function mode by calling
              the function  GPIO_Init();
-      
-      (#) Initialise and configure the CAN using CAN_Init() and 
-          CAN_FilterInit() functions.   
-                 
+
+      (#) Initialise and configure the CAN using CAN_Init() and
+          CAN_FilterInit() functions.
+
       (#) Transmit the desired CAN frame using CAN_Transmit() function.
-           
+
       (#) Check the transmission of a CAN frame using CAN_TransmitStatus()
           function.
-                 
+
       (#) Cancel the transmission of a CAN frame using CAN_CancelTransmit()
-          function.  
-              
-      (#) Receive a CAN frame using CAN_Recieve() function.
-           
+          function.
+
+      (#) Receive a CAN frame using CAN_Receive() function.
+
       (#) Release the receive FIFOs using CAN_FIFORelease() function.
-                 
-      (#) Return the number of pending received frames using 
-          CAN_MessagePending() function.            
-                     
+
+      (#) Return the number of pending received frames using
+          CAN_MessagePending() function.
+
       (#) To control CAN events you can use one of the following two methods:
-        (++) Check on CAN flags using the CAN_GetFlagStatus() function.  
-        (++) Use CAN interrupts through the function CAN_ITConfig() at 
-             initialization phase and CAN_GetITStatus() function into 
+        (++) Check on CAN flags using the CAN_GetFlagStatus() function.
+        (++) Use CAN interrupts through the function CAN_ITConfig() at
+             initialization phase and CAN_GetITStatus() function into
              interrupt routines to check if the event has occurred or not.
              After checking on a flag you should clear it using CAN_ClearFlag()
-             function. And after checking on an interrupt event you should 
-             clear it using CAN_ClearITPendingBit() function.            
-                 
-                
+             function. And after checking on an interrupt event you should
+             clear it using CAN_ClearITPendingBit() function.
+
+
 @endverbatim
-           
+
   ******************************************************************************
   * @attention
   *
@@ -72,13 +72,13 @@
   *
   *        http://www.st.com/software_license_agreement_liberty_v2
   *
-  * Unless required by applicable law or agreed to in writing, software 
-  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   * See the License for the specific language governing permissions and
   * limitations under the License.
   *
-  ******************************************************************************  
+  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -89,10 +89,10 @@
   * @{
   */
 
-/** @defgroup CAN 
+/** @defgroup CAN
   * @brief CAN driver modules
   * @{
-  */ 
+  */
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 
@@ -111,20 +111,20 @@
 #define SLAK_TIMEOUT      ((uint32_t)0x0000FFFF)
 
 /* Flags in TSR register */
-#define CAN_FLAGS_TSR     ((uint32_t)0x08000000) 
+#define CAN_FLAGS_TSR     ((uint32_t)0x08000000)
 /* Flags in RF1R register */
-#define CAN_FLAGS_RF1R    ((uint32_t)0x04000000) 
+#define CAN_FLAGS_RF1R    ((uint32_t)0x04000000)
 /* Flags in RF0R register */
-#define CAN_FLAGS_RF0R    ((uint32_t)0x02000000) 
+#define CAN_FLAGS_RF0R    ((uint32_t)0x02000000)
 /* Flags in MSR register */
-#define CAN_FLAGS_MSR     ((uint32_t)0x01000000) 
+#define CAN_FLAGS_MSR     ((uint32_t)0x01000000)
 /* Flags in ESR register */
-#define CAN_FLAGS_ESR     ((uint32_t)0x00F00000) 
+#define CAN_FLAGS_ESR     ((uint32_t)0x00F00000)
 
 /* Mailboxes definition */
 #define CAN_TXMAILBOX_0   ((uint8_t)0x00)
 #define CAN_TXMAILBOX_1   ((uint8_t)0x01)
-#define CAN_TXMAILBOX_2   ((uint8_t)0x02) 
+#define CAN_TXMAILBOX_2   ((uint8_t)0x02)
 
 #define CAN_MODE_MASK     ((uint32_t) 0x00000003)
 
@@ -139,26 +139,26 @@ static ITStatus CheckITStatus(uint32_t CAN_Reg, uint32_t It_Bit);
   */
 
 /** @defgroup CAN_Group1 Initialization and Configuration functions
- *  @brief    Initialization and Configuration functions 
+ *  @brief    Initialization and Configuration functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
               ##### Initialization and Configuration functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to 
-      (+) Initialize the CAN peripherals : Prescaler, operating mode, the maximum 
-          number of time quanta to perform resynchronization, the number of time 
-          quanta in Bit Segment 1 and 2 and many other modes. 
+ ===============================================================================
+    [..] This section provides functions allowing to
+      (+) Initialize the CAN peripherals : Prescaler, operating mode, the maximum
+          number of time quanta to perform resynchronization, the number of time
+          quanta in Bit Segment 1 and 2 and many other modes.
           Refer to  @ref CAN_InitTypeDef  for more details.
-      (+) Configures the CAN reception filter.                                      
+      (+) Configures the CAN reception filter.
       (+) Select the start bank filter for slave CAN.
       (+) Enables or disables the Debug Freeze mode for CAN
       (+)Enables or disables the CAN Time Trigger Operation communication mode
-   
+
 @endverbatim
   * @{
   */
-  
+
 /**
   * @brief  Deinitializes the CAN peripheral registers to their default reset values.
   * @param  CANx: where x can be 1 or 2 to select the CAN peripheral.
@@ -168,7 +168,7 @@ void CAN_DeInit(CAN_TypeDef* CANx)
 {
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
- 
+
   if (CANx == CAN1)
   {
     /* Enable CAN1 reset state */
@@ -177,7 +177,7 @@ void CAN_DeInit(CAN_TypeDef* CANx)
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_CAN1, DISABLE);
   }
   else
-  {  
+  {
     /* Enable CAN2 reset state */
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_CAN2, ENABLE);
     /* Release CAN2 from reset state */
@@ -191,7 +191,7 @@ void CAN_DeInit(CAN_TypeDef* CANx)
   * @param  CANx: where x can be 1 or 2 to select the CAN peripheral.
   * @param  CAN_InitStruct: pointer to a CAN_InitTypeDef structure that contains
   *         the configuration information for the CAN peripheral.
-  * @retval Constant indicates initialization succeed which will be 
+  * @retval Constant indicates initialization succeed which will be
   *         CAN_InitStatus_Failed or CAN_InitStatus_Success.
   */
 uint8_t CAN_Init(CAN_TypeDef* CANx, CAN_InitTypeDef* CAN_InitStruct)
@@ -229,7 +229,7 @@ uint8_t CAN_Init(CAN_TypeDef* CANx, CAN_InitTypeDef* CAN_InitStruct)
   {
     InitStatus = CAN_InitStatus_Failed;
   }
-  else 
+  else
   {
     /* Set the time triggered communication mode */
     if (CAN_InitStruct->CAN_TTCM == ENABLE)
@@ -357,13 +357,13 @@ void CAN_FilterInit(CAN_FilterInitTypeDef* CAN_FilterInitStruct)
 
     /* First 16-bit identifier and First 16-bit mask */
     /* Or First 16-bit identifier and Second 16-bit identifier */
-    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR1 = 
+    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR1 =
        ((0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterMaskIdLow) << 16) |
         (0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterIdLow);
 
     /* Second 16-bit identifier and Second 16-bit mask */
     /* Or Third 16-bit identifier and Fourth 16-bit identifier */
-    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR2 = 
+    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR2 =
        ((0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterMaskIdHigh) << 16) |
         (0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterIdHigh);
   }
@@ -373,11 +373,11 @@ void CAN_FilterInit(CAN_FilterInitTypeDef* CAN_FilterInitStruct)
     /* 32-bit scale for the filter */
     CAN1->FS1R |= filter_number_bit_pos;
     /* 32-bit identifier or First 32-bit identifier */
-    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR1 = 
+    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR1 =
        ((0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterIdHigh) << 16) |
         (0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterIdLow);
     /* 32-bit mask or Second 32-bit identifier */
-    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR2 = 
+    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR2 =
        ((0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterMaskIdHigh) << 16) |
         (0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterMaskIdLow);
   }
@@ -406,7 +406,7 @@ void CAN_FilterInit(CAN_FilterInitTypeDef* CAN_FilterInitStruct)
     /* FIFO 1 assignation for the filter */
     CAN1->FFA1R |= (uint32_t)filter_number_bit_pos;
   }
-  
+
   /* Filter activation */
   if (CAN_FilterInitStruct->CAN_FilterActivation == ENABLE)
   {
@@ -425,37 +425,37 @@ void CAN_FilterInit(CAN_FilterInitTypeDef* CAN_FilterInitStruct)
 void CAN_StructInit(CAN_InitTypeDef* CAN_InitStruct)
 {
   /* Reset CAN init structure parameters values */
-  
+
   /* Initialize the time triggered communication mode */
   CAN_InitStruct->CAN_TTCM = DISABLE;
-  
+
   /* Initialize the automatic bus-off management */
   CAN_InitStruct->CAN_ABOM = DISABLE;
-  
+
   /* Initialize the automatic wake-up mode */
   CAN_InitStruct->CAN_AWUM = DISABLE;
-  
+
   /* Initialize the no automatic retransmission */
   CAN_InitStruct->CAN_NART = DISABLE;
-  
+
   /* Initialize the receive FIFO locked mode */
   CAN_InitStruct->CAN_RFLM = DISABLE;
-  
+
   /* Initialize the transmit FIFO priority */
   CAN_InitStruct->CAN_TXFP = DISABLE;
-  
+
   /* Initialize the CAN_Mode member */
   CAN_InitStruct->CAN_Mode = CAN_Mode_Normal;
-  
+
   /* Initialize the CAN_SJW member */
   CAN_InitStruct->CAN_SJW = CAN_SJW_1tq;
-  
+
   /* Initialize the CAN_BS1 member */
   CAN_InitStruct->CAN_BS1 = CAN_BS1_4tq;
-  
+
   /* Initialize the CAN_BS2 member */
   CAN_InitStruct->CAN_BS2 = CAN_BS2_3tq;
-  
+
   /* Initialize the CAN_Prescaler member */
   CAN_InitStruct->CAN_Prescaler = 1;
 }
@@ -465,18 +465,18 @@ void CAN_StructInit(CAN_InitTypeDef* CAN_InitStruct)
   * @param  CAN_BankNumber: Select the start slave bank filter from 1..27.
   * @retval None
   */
-void CAN_SlaveStartBank(uint8_t CAN_BankNumber) 
+void CAN_SlaveStartBank(uint8_t CAN_BankNumber)
 {
   /* Check the parameters */
   assert_param(IS_CAN_BANKNUMBER(CAN_BankNumber));
-  
+
   /* Enter Initialisation mode for the filter */
   CAN1->FMR |= FMR_FINIT;
-  
+
   /* Select the start slave bank */
   CAN1->FMR &= (uint32_t)0xFFFFC0F1 ;
   CAN1->FMR |= (uint32_t)(CAN_BankNumber)<<8;
-  
+
   /* Leave Initialisation mode for the filter */
   CAN1->FMR &= ~FMR_FINIT;
 }
@@ -484,9 +484,9 @@ void CAN_SlaveStartBank(uint8_t CAN_BankNumber)
 /**
   * @brief  Enables or disables the DBG Freeze for CAN.
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
-  * @param  NewState: new state of the CAN peripheral. 
+  * @param  NewState: new state of the CAN peripheral.
   *          This parameter can be: ENABLE (CAN reception/transmission is frozen
-  *          during debug. Reception FIFOs can still be accessed/controlled normally) 
+  *          during debug. Reception FIFOs can still be accessed/controlled normally)
   *          or DISABLE (CAN is working during debug).
   * @retval None
   */
@@ -495,7 +495,7 @@ void CAN_DBGFreeze(CAN_TypeDef* CANx, FunctionalState NewState)
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_FUNCTIONAL_STATE(NewState));
-  
+
   if (NewState != DISABLE)
   {
     /* Enable Debug Freeze  */
@@ -511,13 +511,13 @@ void CAN_DBGFreeze(CAN_TypeDef* CANx, FunctionalState NewState)
 
 /**
   * @brief  Enables or disables the CAN Time TriggerOperation communication mode.
-  * @note   DLC must be programmed as 8 in order Time Stamp (2 bytes) to be 
-  *         sent over the CAN bus.  
+  * @note   DLC must be programmed as 8 in order Time Stamp (2 bytes) to be
+  *         sent over the CAN bus.
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
   * @param  NewState: Mode new state. This parameter can be: ENABLE or DISABLE.
   *         When enabled, Time stamp (TIME[15:0]) value is  sent in the last two
-  *         data bytes of the 8-byte message: TIME[7:0] in data byte 6 and TIME[15:8] 
-  *         in data byte 7. 
+  *         data bytes of the 8-byte message: TIME[7:0] in data byte 6 and TIME[15:8]
+  *         in data byte 7.
   * @retval None
   */
 void CAN_TTComModeCmd(CAN_TypeDef* CANx, FunctionalState NewState)
@@ -552,17 +552,17 @@ void CAN_TTComModeCmd(CAN_TypeDef* CANx, FunctionalState NewState)
 
 
 /** @defgroup CAN_Group2 CAN Frames Transmission functions
- *  @brief    CAN Frames Transmission functions 
+ *  @brief    CAN Frames Transmission functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
                 ##### CAN Frames Transmission functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to 
+ ===============================================================================
+    [..] This section provides functions allowing to
       (+) Initiate and transmit a CAN frame message (if there is an empty mailbox).
       (+) Check the transmission status of a CAN Frame
       (+) Cancel a transmit request
-   
+
 @endverbatim
   * @{
   */
@@ -607,7 +607,7 @@ uint8_t CAN_Transmit(CAN_TypeDef* CANx, CanTxMsg* TxMessage)
     CANx->sTxMailBox[transmit_mailbox].TIR &= TMIDxR_TXRQ;
     if (TxMessage->IDE == CAN_Id_Standard)
     {
-      assert_param(IS_CAN_STDID(TxMessage->StdId));  
+      assert_param(IS_CAN_STDID(TxMessage->StdId));
       CANx->sTxMailBox[transmit_mailbox].TIR |= ((TxMessage->StdId << 21) | \
                                                   TxMessage->RTR);
     }
@@ -618,18 +618,18 @@ uint8_t CAN_Transmit(CAN_TypeDef* CANx, CanTxMsg* TxMessage)
                                                   TxMessage->IDE | \
                                                   TxMessage->RTR);
     }
-    
+
     /* Set up the DLC */
     TxMessage->DLC &= (uint8_t)0x0000000F;
     CANx->sTxMailBox[transmit_mailbox].TDTR &= (uint32_t)0xFFFFFFF0;
     CANx->sTxMailBox[transmit_mailbox].TDTR |= TxMessage->DLC;
 
     /* Set up the data field */
-    CANx->sTxMailBox[transmit_mailbox].TDLR = (((uint32_t)TxMessage->Data[3] << 24) | 
+    CANx->sTxMailBox[transmit_mailbox].TDLR = (((uint32_t)TxMessage->Data[3] << 24) |
                                              ((uint32_t)TxMessage->Data[2] << 16) |
-                                             ((uint32_t)TxMessage->Data[1] << 8) | 
+                                             ((uint32_t)TxMessage->Data[1] << 8) |
                                              ((uint32_t)TxMessage->Data[0]));
-    CANx->sTxMailBox[transmit_mailbox].TDHR = (((uint32_t)TxMessage->Data[7] << 24) | 
+    CANx->sTxMailBox[transmit_mailbox].TDHR = (((uint32_t)TxMessage->Data[7] << 24) |
                                              ((uint32_t)TxMessage->Data[6] << 16) |
                                              ((uint32_t)TxMessage->Data[5] << 8) |
                                              ((uint32_t)TxMessage->Data[4]));
@@ -643,7 +643,7 @@ uint8_t CAN_Transmit(CAN_TypeDef* CANx, CanTxMsg* TxMessage)
   * @brief  Checks the transmission status of a CAN Frame.
   * @param  CANx: where x can be 1 or 2 to select the CAN peripheral.
   * @param  TransmitMailbox: the number of the mailbox that is used for transmission.
-  * @retval CAN_TxStatus_Ok if the CAN driver transmits the message, 
+  * @retval CAN_TxStatus_Ok if the CAN driver transmits the message,
   *         CAN_TxStatus_Failed in an other case.
   */
 uint8_t CAN_TransmitStatus(CAN_TypeDef* CANx, uint8_t TransmitMailbox)
@@ -653,16 +653,16 @@ uint8_t CAN_TransmitStatus(CAN_TypeDef* CANx, uint8_t TransmitMailbox)
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_CAN_TRANSMITMAILBOX(TransmitMailbox));
- 
+
   switch (TransmitMailbox)
   {
-    case (CAN_TXMAILBOX_0): 
+    case (CAN_TXMAILBOX_0):
       state =   CANx->TSR &  (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0);
       break;
-    case (CAN_TXMAILBOX_1): 
+    case (CAN_TXMAILBOX_1):
       state =   CANx->TSR &  (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1);
       break;
-    case (CAN_TXMAILBOX_2): 
+    case (CAN_TXMAILBOX_2):
       state =   CANx->TSR &  (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2);
       break;
     default:
@@ -724,17 +724,17 @@ void CAN_CancelTransmit(CAN_TypeDef* CANx, uint8_t Mailbox)
 
 
 /** @defgroup CAN_Group3 CAN Frames Reception functions
- *  @brief    CAN Frames Reception functions 
+ *  @brief    CAN Frames Reception functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
                 ##### CAN Frames Reception functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to 
+ ===============================================================================
+    [..] This section provides functions allowing to
       (+) Receive a correct CAN frame
       (+) Release a specified receive FIFO (2 FIFOs are available)
       (+) Return the number of the pending received CAN frames
-   
+
 @endverbatim
   * @{
   */
@@ -762,7 +762,7 @@ void CAN_Receive(CAN_TypeDef* CANx, uint8_t FIFONumber, CanRxMsg* RxMessage)
   {
     RxMessage->ExtId = (uint32_t)0x1FFFFFFF & (CANx->sFIFOMailBox[FIFONumber].RIR >> 3);
   }
-  
+
   RxMessage->RTR = (uint8_t)0x02 & CANx->sFIFOMailBox[FIFONumber].RIR;
   /* Get the DLC */
   RxMessage->DLC = (uint8_t)0x0F & CANx->sFIFOMailBox[FIFONumber].RDTR;
@@ -845,36 +845,36 @@ uint8_t CAN_MessagePending(CAN_TypeDef* CANx, uint8_t FIFONumber)
 
 
 /** @defgroup CAN_Group4 CAN Operation modes functions
- *  @brief    CAN Operation modes functions 
+ *  @brief    CAN Operation modes functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
                     ##### CAN Operation modes functions #####
- ===============================================================================  
+ ===============================================================================
     [..] This section provides functions allowing to select the CAN Operation modes
       (+) sleep mode
-      (+) normal mode 
+      (+) normal mode
       (+) initialization mode
-   
+
 @endverbatim
   * @{
   */
-  
-  
+
+
 /**
   * @brief  Selects the CAN Operation mode.
   * @param  CAN_OperatingMode: CAN Operating Mode.
   *         This parameter can be one of @ref CAN_OperatingMode_TypeDef enumeration.
-  * @retval status of the requested mode which can be 
-  *         - CAN_ModeStatus_Failed:  CAN failed entering the specific mode 
-  *         - CAN_ModeStatus_Success: CAN Succeed entering the specific mode 
+  * @retval status of the requested mode which can be
+  *         - CAN_ModeStatus_Failed:  CAN failed entering the specific mode
+  *         - CAN_ModeStatus_Success: CAN Succeed entering the specific mode
   */
 uint8_t CAN_OperatingModeRequest(CAN_TypeDef* CANx, uint8_t CAN_OperatingMode)
 {
   uint8_t status = CAN_ModeStatus_Failed;
-  
+
   /* Timeout for INAK or also for SLAK bits*/
-  uint32_t timeout = INAK_TIMEOUT; 
+  uint32_t timeout = INAK_TIMEOUT;
 
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
@@ -953,13 +953,13 @@ uint8_t CAN_OperatingModeRequest(CAN_TypeDef* CANx, uint8_t CAN_OperatingMode)
 uint8_t CAN_Sleep(CAN_TypeDef* CANx)
 {
   uint8_t sleepstatus = CAN_Sleep_Failed;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-    
+
   /* Request Sleep mode */
    CANx->MCR = (((CANx->MCR) & (uint32_t)(~(uint32_t)CAN_MCR_INRQ)) | CAN_MCR_SLEEP);
-   
+
   /* Sleep mode status */
   if ((CANx->MSR & (CAN_MSR_SLAK|CAN_MSR_INAK)) == CAN_MSR_SLAK)
   {
@@ -979,13 +979,13 @@ uint8_t CAN_WakeUp(CAN_TypeDef* CANx)
 {
   uint32_t wait_slak = SLAK_TIMEOUT;
   uint8_t wakeupstatus = CAN_WakeUp_Failed;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-    
+
   /* Wake up request */
   CANx->MCR &= ~(uint32_t)CAN_MCR_SLEEP;
-    
+
   /* Sleep mode status */
   while(((CANx->MSR & CAN_MSR_SLAK) == CAN_MSR_SLAK)&&(wait_slak!=0x00))
   {
@@ -1005,73 +1005,73 @@ uint8_t CAN_WakeUp(CAN_TypeDef* CANx)
 
 
 /** @defgroup CAN_Group5 CAN Bus Error management functions
- *  @brief    CAN Bus Error management functions 
+ *  @brief    CAN Bus Error management functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
                 ##### CAN Bus Error management functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to 
+ ===============================================================================
+    [..] This section provides functions allowing to
       (+) Return the CANx's last error code (LEC)
       (+) Return the CANx Receive Error Counter (REC)
       (+) Return the LSB of the 9-bit CANx Transmit Error Counter(TEC).
-   
+
       -@- If TEC is greater than 255, The CAN is in bus-off state.
       -@- if REC or TEC are greater than 96, an Error warning flag occurs.
       -@- if REC or TEC are greater than 127, an Error Passive Flag occurs.
-                        
+
 @endverbatim
   * @{
   */
-  
+
 /**
   * @brief  Returns the CANx's last error code (LEC).
   * @param  CANx: where x can be 1 or 2 to select the CAN peripheral.
-  * @retval Error code: 
-  *          - CAN_ERRORCODE_NoErr: No Error  
+  * @retval Error code:
+  *          - CAN_ERRORCODE_NoErr: No Error
   *          - CAN_ERRORCODE_StuffErr: Stuff Error
   *          - CAN_ERRORCODE_FormErr: Form Error
   *          - CAN_ERRORCODE_ACKErr : Acknowledgment Error
   *          - CAN_ERRORCODE_BitRecessiveErr: Bit Recessive Error
   *          - CAN_ERRORCODE_BitDominantErr: Bit Dominant Error
   *          - CAN_ERRORCODE_CRCErr: CRC Error
-  *          - CAN_ERRORCODE_SoftwareSetErr: Software Set Error  
+  *          - CAN_ERRORCODE_SoftwareSetErr: Software Set Error
   */
 uint8_t CAN_GetLastErrorCode(CAN_TypeDef* CANx)
 {
   uint8_t errorcode=0;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-  
+
   /* Get the error code*/
   errorcode = (((uint8_t)CANx->ESR) & (uint8_t)CAN_ESR_LEC);
-  
+
   /* Return the error code*/
   return errorcode;
 }
 
 /**
   * @brief  Returns the CANx Receive Error Counter (REC).
-  * @note   In case of an error during reception, this counter is incremented 
-  *         by 1 or by 8 depending on the error condition as defined by the CAN 
-  *         standard. After every successful reception, the counter is 
-  *         decremented by 1 or reset to 120 if its value was higher than 128. 
-  *         When the counter value exceeds 127, the CAN controller enters the 
-  *         error passive state.  
-  * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.  
-  * @retval CAN Receive Error Counter. 
+  * @note   In case of an error during reception, this counter is incremented
+  *         by 1 or by 8 depending on the error condition as defined by the CAN
+  *         standard. After every successful reception, the counter is
+  *         decremented by 1 or reset to 120 if its value was higher than 128.
+  *         When the counter value exceeds 127, the CAN controller enters the
+  *         error passive state.
+  * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
+  * @retval CAN Receive Error Counter.
   */
 uint8_t CAN_GetReceiveErrorCounter(CAN_TypeDef* CANx)
 {
   uint8_t counter=0;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-  
+
   /* Get the Receive Error Counter*/
   counter = (uint8_t)((CANx->ESR & CAN_ESR_REC)>> 24);
-  
+
   /* Return the Receive Error Counter*/
   return counter;
 }
@@ -1080,18 +1080,18 @@ uint8_t CAN_GetReceiveErrorCounter(CAN_TypeDef* CANx)
 /**
   * @brief  Returns the LSB of the 9-bit CANx Transmit Error Counter(TEC).
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
-  * @retval LSB of the 9-bit CAN Transmit Error Counter. 
+  * @retval LSB of the 9-bit CAN Transmit Error Counter.
   */
 uint8_t CAN_GetLSBTransmitErrorCounter(CAN_TypeDef* CANx)
 {
   uint8_t counter=0;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-  
+
   /* Get the LSB of the 9-bit CANx Transmit Error Counter(TEC) */
   counter = (uint8_t)((CANx->ESR & CAN_ESR_TEC)>> 16);
-  
+
   /* Return the LSB of the 9-bit CANx Transmit Error Counter(TEC) */
   return counter;
 }
@@ -1102,185 +1102,185 @@ uint8_t CAN_GetLSBTransmitErrorCounter(CAN_TypeDef* CANx)
 /** @defgroup CAN_Group6 Interrupts and flags management functions
  *  @brief   Interrupts and flags management functions
  *
-@verbatim   
+@verbatim
  ===============================================================================
               ##### Interrupts and flags management functions #####
- ===============================================================================  
+ ===============================================================================
 
-     [..] This section provides functions allowing to configure the CAN Interrupts 
+     [..] This section provides functions allowing to configure the CAN Interrupts
           and to get the status and clear flags and Interrupts pending bits.
-  
+
           The CAN provides 14 Interrupts sources and 15 Flags:
 
-   
+
   *** Flags ***
   =============
-    [..] The 15 flags can be divided on 4 groups: 
+    [..] The 15 flags can be divided on 4 groups:
 
       (+) Transmit Flags
-        (++) CAN_FLAG_RQCP0, 
-        (++) CAN_FLAG_RQCP1, 
+        (++) CAN_FLAG_RQCP0,
+        (++) CAN_FLAG_RQCP1,
         (++) CAN_FLAG_RQCP2  : Request completed MailBoxes 0, 1 and 2  Flags
                                Set when when the last request (transmit or abort)
-                               has been performed. 
+                               has been performed.
 
       (+) Receive Flags
 
 
         (++) CAN_FLAG_FMP0,
-        (++) CAN_FLAG_FMP1   : FIFO 0 and 1 Message Pending Flags 
-                               set to signal that messages are pending in the receive 
+        (++) CAN_FLAG_FMP1   : FIFO 0 and 1 Message Pending Flags
+                               set to signal that messages are pending in the receive
                                FIFO.
-                               These Flags are cleared only by hardware. 
+                               These Flags are cleared only by hardware.
 
         (++) CAN_FLAG_FF0,
         (++) CAN_FLAG_FF1    : FIFO 0 and 1 Full Flags
-                               set when three messages are stored in the selected 
-                               FIFO.                        
+                               set when three messages are stored in the selected
+                               FIFO.
 
-        (++) CAN_FLAG_FOV0              
+        (++) CAN_FLAG_FOV0
         (++) CAN_FLAG_FOV1   : FIFO 0 and 1 Overrun Flags
-                               set when a new message has been received and passed 
-                               the filter while the FIFO was full.         
+                               set when a new message has been received and passed
+                               the filter while the FIFO was full.
 
       (+) Operating Mode Flags
 
         (++) CAN_FLAG_WKU    : Wake up Flag
-                               set to signal that a SOF bit has been detected while 
-                               the CAN hardware was in Sleep mode. 
-        
+                               set to signal that a SOF bit has been detected while
+                               the CAN hardware was in Sleep mode.
+
         (++) CAN_FLAG_SLAK   : Sleep acknowledge Flag
-                               Set to signal that the CAN has entered Sleep Mode. 
-    
+                               Set to signal that the CAN has entered Sleep Mode.
+
       (+) Error Flags
 
         (++) CAN_FLAG_EWG    : Error Warning Flag
-                               Set when the warning limit has been reached (Receive 
-                               Error Counter or Transmit Error Counter greater than 96). 
+                               Set when the warning limit has been reached (Receive
+                               Error Counter or Transmit Error Counter greater than 96).
                                This Flag is cleared only by hardware.
-                            
+
         (++) CAN_FLAG_EPV    : Error Passive Flag
-                               Set when the Error Passive limit has been reached 
-                               (Receive Error Counter or Transmit Error Counter 
+                               Set when the Error Passive limit has been reached
+                               (Receive Error Counter or Transmit Error Counter
                                greater than 127).
                                This Flag is cleared only by hardware.
-                             
+
         (++) CAN_FLAG_BOF    : Bus-Off Flag
-                               set when CAN enters the bus-off state. The bus-off 
+                               set when CAN enters the bus-off state. The bus-off
                                state is entered on TEC overflow, greater than 255.
                                This Flag is cleared only by hardware.
-                                   
+
         (++) CAN_FLAG_LEC    : Last error code Flag
                                set If a message has been transferred (reception or
-                               transmission) with error, and the error code is hold.              
-                           
+                               transmission) with error, and the error code is hold.
+
   *** Interrupts ***
   ==================
-    [..] The 14 interrupts can be divided on 4 groups: 
-  
+    [..] The 14 interrupts can be divided on 4 groups:
+
       (+) Transmit interrupt
-  
+
         (++) CAN_IT_TME   :  Transmit mailbox empty Interrupt
-                             if enabled, this interrupt source is pending when 
-                             no transmit request are pending for Tx mailboxes.      
+                             if enabled, this interrupt source is pending when
+                             no transmit request are pending for Tx mailboxes.
 
       (+) Receive Interrupts
-         
+
         (++) CAN_IT_FMP0,
         (++) CAN_IT_FMP1    :  FIFO 0 and FIFO1 message pending Interrupts
-                               if enabled, these interrupt sources are pending 
+                               if enabled, these interrupt sources are pending
                                when messages are pending in the receive FIFO.
-                               The corresponding interrupt pending bits are cleared 
+                               The corresponding interrupt pending bits are cleared
                                only by hardware.
-                
-        (++) CAN_IT_FF0,              
+
+        (++) CAN_IT_FF0,
         (++) CAN_IT_FF1     :  FIFO 0 and FIFO1 full Interrupts
-                               if enabled, these interrupt sources are pending 
+                               if enabled, these interrupt sources are pending
                                when three messages are stored in the selected FIFO.
-        
-        (++) CAN_IT_FOV0,        
-        (++) CAN_IT_FOV1    :  FIFO 0 and FIFO1 overrun Interrupts        
-                               if enabled, these interrupt sources are pending 
-                               when a new message has been received and passed 
+
+        (++) CAN_IT_FOV0,
+        (++) CAN_IT_FOV1    :  FIFO 0 and FIFO1 overrun Interrupts
+                               if enabled, these interrupt sources are pending
+                               when a new message has been received and passed
                                the filter while the FIFO was full.
 
       (+) Operating Mode Interrupts
-         
-        (++) CAN_IT_WKU     :  Wake-up Interrupt
-                               if enabled, this interrupt source is pending when 
-                               a SOF bit has been detected while the CAN hardware 
-                               was in Sleep mode.
-                                  
-        (++) CAN_IT_SLK     :  Sleep acknowledge Interrupt
-                               if enabled, this interrupt source is pending when 
-                               the CAN has entered Sleep Mode.       
 
-      (+) Error Interrupts 
-        
-        (++) CAN_IT_EWG     :  Error warning Interrupt 
+        (++) CAN_IT_WKU     :  Wake-up Interrupt
                                if enabled, this interrupt source is pending when
-                               the warning limit has been reached (Receive Error 
-                               Counter or Transmit Error Counter=96). 
-                               
-        (++) CAN_IT_EPV     :  Error passive Interrupt        
+                               a SOF bit has been detected while the CAN hardware
+                               was in Sleep mode.
+
+        (++) CAN_IT_SLK     :  Sleep acknowledge Interrupt
                                if enabled, this interrupt source is pending when
-                               the Error Passive limit has been reached (Receive 
+                               the CAN has entered Sleep Mode.
+
+      (+) Error Interrupts
+
+        (++) CAN_IT_EWG     :  Error warning Interrupt
+                               if enabled, this interrupt source is pending when
+                               the warning limit has been reached (Receive Error
+                               Counter or Transmit Error Counter=96).
+
+        (++) CAN_IT_EPV     :  Error passive Interrupt
+                               if enabled, this interrupt source is pending when
+                               the Error Passive limit has been reached (Receive
                                Error Counter or Transmit Error Counter>127).
-                          
+
         (++) CAN_IT_BOF     :  Bus-off Interrupt
                                if enabled, this interrupt source is pending when
-                               CAN enters the bus-off state. The bus-off state is 
+                               CAN enters the bus-off state. The bus-off state is
                                entered on TEC overflow, greater than 255.
                                This Flag is cleared only by hardware.
-                                  
-        (++) CAN_IT_LEC     :  Last error code Interrupt        
+
+        (++) CAN_IT_LEC     :  Last error code Interrupt
                                if enabled, this interrupt source is pending  when
                                a message has been transferred (reception or
                                transmission) with error, and the error code is hold.
-                          
-        (++) CAN_IT_ERR     :  Error Interrupt
-                               if enabled, this interrupt source is pending when 
-                               an error condition is pending.      
-                      
-    [..] Managing the CAN controller events :
- 
-         The user should identify which mode will be used in his application to 
-         manage the CAN controller events: Polling mode or Interrupt mode.
-  
-      (#) In the Polling Mode it is advised to use the following functions:
-        (++) CAN_GetFlagStatus() : to check if flags events occur. 
-        (++) CAN_ClearFlag()     : to clear the flags events.
-  
 
-  
+        (++) CAN_IT_ERR     :  Error Interrupt
+                               if enabled, this interrupt source is pending when
+                               an error condition is pending.
+
+    [..] Managing the CAN controller events :
+
+         The user should identify which mode will be used in his application to
+         manage the CAN controller events: Polling mode or Interrupt mode.
+
+      (#) In the Polling Mode it is advised to use the following functions:
+        (++) CAN_GetFlagStatus() : to check if flags events occur.
+        (++) CAN_ClearFlag()     : to clear the flags events.
+
+
+
       (#) In the Interrupt Mode it is advised to use the following functions:
         (++) CAN_ITConfig()       : to enable or disable the interrupt source.
         (++) CAN_GetITStatus()    : to check if Interrupt occurs.
-        (++) CAN_ClearITPendingBit() : to clear the Interrupt pending Bit 
+        (++) CAN_ClearITPendingBit() : to clear the Interrupt pending Bit
             (corresponding Flag).
-        -@@-  This function has no impact on CAN_IT_FMP0 and CAN_IT_FMP1 Interrupts 
-             pending bits since there are cleared only by hardware. 
-  
+        -@@-  This function has no impact on CAN_IT_FMP0 and CAN_IT_FMP1 Interrupts
+             pending bits since there are cleared only by hardware.
+
 @endverbatim
   * @{
-  */ 
+  */
 /**
   * @brief  Enables or disables the specified CANx interrupts.
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
   * @param  CAN_IT: specifies the CAN interrupt sources to be enabled or disabled.
-  *          This parameter can be: 
-  *            @arg CAN_IT_TME: Transmit mailbox empty Interrupt 
-  *            @arg CAN_IT_FMP0: FIFO 0 message pending Interrupt 
+  *          This parameter can be:
+  *            @arg CAN_IT_TME: Transmit mailbox empty Interrupt
+  *            @arg CAN_IT_FMP0: FIFO 0 message pending Interrupt
   *            @arg CAN_IT_FF0: FIFO 0 full Interrupt
   *            @arg CAN_IT_FOV0: FIFO 0 overrun Interrupt
-  *            @arg CAN_IT_FMP1: FIFO 1 message pending Interrupt 
+  *            @arg CAN_IT_FMP1: FIFO 1 message pending Interrupt
   *            @arg CAN_IT_FF1: FIFO 1 full Interrupt
   *            @arg CAN_IT_FOV1: FIFO 1 overrun Interrupt
   *            @arg CAN_IT_WKU: Wake-up Interrupt
-  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt  
+  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt
   *            @arg CAN_IT_EWG: Error warning Interrupt
   *            @arg CAN_IT_EPV: Error passive Interrupt
-  *            @arg CAN_IT_BOF: Bus-off Interrupt  
+  *            @arg CAN_IT_BOF: Bus-off Interrupt
   *            @arg CAN_IT_LEC: Last error code Interrupt
   *            @arg CAN_IT_ERR: Error Interrupt
   * @param  NewState: new state of the CAN interrupts.
@@ -1313,95 +1313,95 @@ void CAN_ITConfig(CAN_TypeDef* CANx, uint32_t CAN_IT, FunctionalState NewState)
   *            @arg CAN_FLAG_RQCP0: Request MailBox0 Flag
   *            @arg CAN_FLAG_RQCP1: Request MailBox1 Flag
   *            @arg CAN_FLAG_RQCP2: Request MailBox2 Flag
-  *            @arg CAN_FLAG_FMP0: FIFO 0 Message Pending Flag   
-  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag       
-  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag 
-  *            @arg CAN_FLAG_FMP1: FIFO 1 Message Pending Flag   
-  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag        
-  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag     
+  *            @arg CAN_FLAG_FMP0: FIFO 0 Message Pending Flag
+  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag
+  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag
+  *            @arg CAN_FLAG_FMP1: FIFO 1 Message Pending Flag
+  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag
+  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag
   *            @arg CAN_FLAG_WKU: Wake up Flag
-  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag 
+  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag
   *            @arg CAN_FLAG_EWG: Error Warning Flag
-  *            @arg CAN_FLAG_EPV: Error Passive Flag  
-  *            @arg CAN_FLAG_BOF: Bus-Off Flag    
-  *            @arg CAN_FLAG_LEC: Last error code Flag      
+  *            @arg CAN_FLAG_EPV: Error Passive Flag
+  *            @arg CAN_FLAG_BOF: Bus-Off Flag
+  *            @arg CAN_FLAG_LEC: Last error code Flag
   * @retval The new state of CAN_FLAG (SET or RESET).
   */
 FlagStatus CAN_GetFlagStatus(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
 {
   FlagStatus bitstatus = RESET;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_CAN_GET_FLAG(CAN_FLAG));
-  
+
 
   if((CAN_FLAG & CAN_FLAGS_ESR) != (uint32_t)RESET)
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((CANx->ESR & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
   }
   else if((CAN_FLAG & CAN_FLAGS_MSR) != (uint32_t)RESET)
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((CANx->MSR & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
   }
   else if((CAN_FLAG & CAN_FLAGS_TSR) != (uint32_t)RESET)
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((CANx->TSR & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
   }
   else if((CAN_FLAG & CAN_FLAGS_RF0R) != (uint32_t)RESET)
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((CANx->RF0R & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
   }
   else /* If(CAN_FLAG & CAN_FLAGS_RF1R != (uint32_t)RESET) */
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((uint32_t)(CANx->RF1R & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
@@ -1417,14 +1417,14 @@ FlagStatus CAN_GetFlagStatus(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
   *          This parameter can be one of the following values:
   *            @arg CAN_FLAG_RQCP0: Request MailBox0 Flag
   *            @arg CAN_FLAG_RQCP1: Request MailBox1 Flag
-  *            @arg CAN_FLAG_RQCP2: Request MailBox2 Flag 
-  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag       
-  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag  
-  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag        
-  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag     
+  *            @arg CAN_FLAG_RQCP2: Request MailBox2 Flag
+  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag
+  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag
+  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag
+  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag
   *            @arg CAN_FLAG_WKU: Wake up Flag
-  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag    
-  *            @arg CAN_FLAG_LEC: Last error code Flag        
+  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag
+  *            @arg CAN_FLAG_LEC: Last error code Flag
   * @retval None
   */
 void CAN_ClearFlag(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
@@ -1433,7 +1433,7 @@ void CAN_ClearFlag(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_CAN_CLEAR_FLAG(CAN_FLAG));
-  
+
   if (CAN_FLAG == CAN_FLAG_LEC) /* ESR register */
   {
     /* Clear the selected CAN flags */
@@ -1471,18 +1471,18 @@ void CAN_ClearFlag(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
   * @param  CAN_IT: specifies the CAN interrupt source to check.
   *          This parameter can be one of the following values:
-  *            @arg CAN_IT_TME: Transmit mailbox empty Interrupt 
-  *            @arg CAN_IT_FMP0: FIFO 0 message pending Interrupt 
+  *            @arg CAN_IT_TME: Transmit mailbox empty Interrupt
+  *            @arg CAN_IT_FMP0: FIFO 0 message pending Interrupt
   *            @arg CAN_IT_FF0: FIFO 0 full Interrupt
   *            @arg CAN_IT_FOV0: FIFO 0 overrun Interrupt
-  *            @arg CAN_IT_FMP1: FIFO 1 message pending Interrupt 
+  *            @arg CAN_IT_FMP1: FIFO 1 message pending Interrupt
   *            @arg CAN_IT_FF1: FIFO 1 full Interrupt
   *            @arg CAN_IT_FOV1: FIFO 1 overrun Interrupt
   *            @arg CAN_IT_WKU: Wake-up Interrupt
-  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt  
+  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt
   *            @arg CAN_IT_EWG: Error warning Interrupt
   *            @arg CAN_IT_EPV: Error passive Interrupt
-  *            @arg CAN_IT_BOF: Bus-off Interrupt  
+  *            @arg CAN_IT_BOF: Bus-off Interrupt
   *            @arg CAN_IT_LEC: Last error code Interrupt
   *            @arg CAN_IT_ERR: Error Interrupt
   * @retval The current state of CAN_IT (SET or RESET).
@@ -1493,7 +1493,7 @@ ITStatus CAN_GetITStatus(CAN_TypeDef* CANx, uint32_t CAN_IT)
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_CAN_IT(CAN_IT));
-  
+
   /* check the interrupt enable bit */
  if((CANx->IER & CAN_IT) != RESET)
  {
@@ -1502,59 +1502,59 @@ ITStatus CAN_GetITStatus(CAN_TypeDef* CANx, uint32_t CAN_IT)
     {
       case CAN_IT_TME:
         /* Check CAN_TSR_RQCPx bits */
-        itstatus = CheckITStatus(CANx->TSR, CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2);  
+        itstatus = CheckITStatus(CANx->TSR, CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2);
         break;
       case CAN_IT_FMP0:
         /* Check CAN_RF0R_FMP0 bit */
-        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FMP0);  
+        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FMP0);
         break;
       case CAN_IT_FF0:
         /* Check CAN_RF0R_FULL0 bit */
-        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FULL0);  
+        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FULL0);
         break;
       case CAN_IT_FOV0:
         /* Check CAN_RF0R_FOVR0 bit */
-        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FOVR0);  
+        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FOVR0);
         break;
       case CAN_IT_FMP1:
         /* Check CAN_RF1R_FMP1 bit */
-        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FMP1);  
+        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FMP1);
         break;
       case CAN_IT_FF1:
         /* Check CAN_RF1R_FULL1 bit */
-        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FULL1);  
+        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FULL1);
         break;
       case CAN_IT_FOV1:
         /* Check CAN_RF1R_FOVR1 bit */
-        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FOVR1);  
+        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FOVR1);
         break;
       case CAN_IT_WKU:
         /* Check CAN_MSR_WKUI bit */
-        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_WKUI);  
+        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_WKUI);
         break;
       case CAN_IT_SLK:
         /* Check CAN_MSR_SLAKI bit */
-        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_SLAKI);  
+        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_SLAKI);
         break;
       case CAN_IT_EWG:
         /* Check CAN_ESR_EWGF bit */
-        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_EWGF);  
+        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_EWGF);
         break;
       case CAN_IT_EPV:
         /* Check CAN_ESR_EPVF bit */
-        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_EPVF);  
+        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_EPVF);
         break;
       case CAN_IT_BOF:
         /* Check CAN_ESR_BOFF bit */
-        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_BOFF);  
+        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_BOFF);
         break;
       case CAN_IT_LEC:
         /* Check CAN_ESR_LEC bit */
-        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_LEC);  
+        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_LEC);
         break;
       case CAN_IT_ERR:
-        /* Check CAN_MSR_ERRI bit */ 
-        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_ERRI); 
+        /* Check CAN_MSR_ERRI bit */
+        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_ERRI);
         break;
       default:
         /* in case of error, return RESET */
@@ -1567,7 +1567,7 @@ ITStatus CAN_GetITStatus(CAN_TypeDef* CANx, uint32_t CAN_IT)
    /* in case the Interrupt is not enabled, return RESET */
     itstatus  = RESET;
   }
-  
+
   /* Return the CAN_IT status */
   return  itstatus;
 }
@@ -1583,12 +1583,12 @@ ITStatus CAN_GetITStatus(CAN_TypeDef* CANx, uint32_t CAN_IT)
   *            @arg CAN_IT_FF1: FIFO 1 full Interrupt
   *            @arg CAN_IT_FOV1: FIFO 1 overrun Interrupt
   *            @arg CAN_IT_WKU: Wake-up Interrupt
-  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt  
+  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt
   *            @arg CAN_IT_EWG: Error warning Interrupt
   *            @arg CAN_IT_EPV: Error passive Interrupt
-  *            @arg CAN_IT_BOF: Bus-off Interrupt  
+  *            @arg CAN_IT_BOF: Bus-off Interrupt
   *            @arg CAN_IT_LEC: Last error code Interrupt
-  *            @arg CAN_IT_ERR: Error Interrupt 
+  *            @arg CAN_IT_ERR: Error Interrupt
   * @retval None
   */
 void CAN_ClearITPendingBit(CAN_TypeDef* CANx, uint32_t CAN_IT)
@@ -1601,58 +1601,58 @@ void CAN_ClearITPendingBit(CAN_TypeDef* CANx, uint32_t CAN_IT)
   {
     case CAN_IT_TME:
       /* Clear CAN_TSR_RQCPx (rc_w1)*/
-      CANx->TSR = CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2;  
+      CANx->TSR = CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2;
       break;
     case CAN_IT_FF0:
       /* Clear CAN_RF0R_FULL0 (rc_w1)*/
-      CANx->RF0R = CAN_RF0R_FULL0; 
+      CANx->RF0R = CAN_RF0R_FULL0;
       break;
     case CAN_IT_FOV0:
       /* Clear CAN_RF0R_FOVR0 (rc_w1)*/
-      CANx->RF0R = CAN_RF0R_FOVR0; 
+      CANx->RF0R = CAN_RF0R_FOVR0;
       break;
     case CAN_IT_FF1:
       /* Clear CAN_RF1R_FULL1 (rc_w1)*/
-      CANx->RF1R = CAN_RF1R_FULL1;  
+      CANx->RF1R = CAN_RF1R_FULL1;
       break;
     case CAN_IT_FOV1:
       /* Clear CAN_RF1R_FOVR1 (rc_w1)*/
-      CANx->RF1R = CAN_RF1R_FOVR1; 
+      CANx->RF1R = CAN_RF1R_FOVR1;
       break;
     case CAN_IT_WKU:
       /* Clear CAN_MSR_WKUI (rc_w1)*/
-      CANx->MSR = CAN_MSR_WKUI;  
+      CANx->MSR = CAN_MSR_WKUI;
       break;
     case CAN_IT_SLK:
-      /* Clear CAN_MSR_SLAKI (rc_w1)*/ 
-      CANx->MSR = CAN_MSR_SLAKI;   
+      /* Clear CAN_MSR_SLAKI (rc_w1)*/
+      CANx->MSR = CAN_MSR_SLAKI;
       break;
     case CAN_IT_EWG:
       /* Clear CAN_MSR_ERRI (rc_w1) */
       CANx->MSR = CAN_MSR_ERRI;
-       /* @note the corresponding Flag is cleared by hardware depending on the CAN Bus status*/ 
+       /* @note the corresponding Flag is cleared by hardware depending on the CAN Bus status*/
       break;
     case CAN_IT_EPV:
       /* Clear CAN_MSR_ERRI (rc_w1) */
-      CANx->MSR = CAN_MSR_ERRI; 
+      CANx->MSR = CAN_MSR_ERRI;
        /* @note the corresponding Flag is cleared by hardware depending on the CAN Bus status*/
       break;
     case CAN_IT_BOF:
-      /* Clear CAN_MSR_ERRI (rc_w1) */ 
-      CANx->MSR = CAN_MSR_ERRI; 
+      /* Clear CAN_MSR_ERRI (rc_w1) */
+      CANx->MSR = CAN_MSR_ERRI;
        /* @note the corresponding Flag is cleared by hardware depending on the CAN Bus status*/
        break;
     case CAN_IT_LEC:
       /*  Clear LEC bits */
-      CANx->ESR = RESET; 
+      CANx->ESR = RESET;
       /* Clear CAN_MSR_ERRI (rc_w1) */
-      CANx->MSR = CAN_MSR_ERRI; 
+      CANx->MSR = CAN_MSR_ERRI;
       break;
     case CAN_IT_ERR:
       /*Clear LEC bits */
-      CANx->ESR = RESET; 
+      CANx->ESR = RESET;
       /* Clear CAN_MSR_ERRI (rc_w1) */
-      CANx->MSR = CAN_MSR_ERRI; 
+      CANx->MSR = CAN_MSR_ERRI;
        /* @note BOFF, EPVF and EWGF Flags are cleared by hardware depending on the CAN Bus status*/
        break;
     default:
@@ -1672,7 +1672,7 @@ void CAN_ClearITPendingBit(CAN_TypeDef* CANx, uint32_t CAN_IT)
 static ITStatus CheckITStatus(uint32_t CAN_Reg, uint32_t It_Bit)
 {
   ITStatus pendingbitstatus = RESET;
-  
+
   if ((CAN_Reg & It_Bit) != (uint32_t)RESET)
   {
     /* CAN_IT is set */

--- a/src/uart.cpp
+++ b/src/uart.cpp
@@ -89,12 +89,12 @@ void UART::init_UART(uint32_t baudrate, uart_mode_t mode)
   }
 
   USART_InitStruct.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
-  USART_InitStruct.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;//Set to both recieve and send
+  USART_InitStruct.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;//Set to both receive and send
   USART_Init(c_->dev, &USART_InitStruct);
   //USART_OverSampling8Cmd(c_->dev, ENABLE);//Please don't break anything
 
   // Throw interrupts on byte receive
-  USART_ITConfig(c_->dev, USART_IT_RXNE, ENABLE);//enable interupts on recieve
+  USART_ITConfig(c_->dev, USART_IT_RXNE, ENABLE);//enable interupts on receive
   USART_Cmd(c_->dev, ENABLE);//reenable the usart
 }
 


### PR DESCRIPTION
when I saved the files after fixing the typos, a bunch of white space was auto-removed from a couple of the files. That is why two of the files have so many 'changed' lines.