### PR TITLE
Fixed PWM for TIM1 and TIM8

### DIFF
--- a/src/pwm.cpp
+++ b/src/pwm.cpp
@@ -113,6 +113,12 @@ void PWM_OUT::init(const pwm_hardware_struct_t* pwm_init, uint16_t frequency, ui
     break;
   }
 
+  // Set Main Output Enable Bit
+  if (TIMPtr == TIM1 || TIMPtr == TIM8)
+  {
+    TIM_CtrlPWMOutputs(TIMPtr, ENABLE);
+  }
+
   TIM_ARRPreloadConfig(TIMPtr, ENABLE);
   TIM_Cmd(TIMPtr, ENABLE);
 }


### PR DESCRIPTION
Main output enable bit was not being set (only required for Advanced Control Timers TIM1 and TIM8), so PWM signals were not output on pins 7-10 of the flexi-io. 