### PR TITLE
Backup SRAM cleanup

### DIFF
--- a/examples/backup_sram/main.cpp
+++ b/examples/backup_sram/main.cpp
@@ -37,16 +37,24 @@
 #include "revo_f4.h"
 #include "backup_sram.h"
 #include "vcp.h"
+#include "printf.h"
 
 struct BackupData
 {
+    static constexpr uint32_t CHECKSUM_START = 0xA5A5;
+
     uint32_t reset_count;
     uint32_t some_data;
     uint32_t checksum;
 
+    BackupData()
+    {
+        memset(this, 0, sizeof(BackupData));
+    }
+
     uint32_t compute_checksum()
     {
-        uint32_t crc = 0;
+        uint32_t crc = CHECKSUM_START;
         for (size_t offset = 0; offset <= sizeof(BackupData) - sizeof(checksum) - sizeof(crc); offset++)
         {
             crc ^= *reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(this) + offset);
@@ -62,27 +70,13 @@ void restart()
 
 int main()
 {
-	systemInit();
-    // backup_sram_init();
+    systemInit();
     VCP vcp;
     vcp.init();
     backup_sram_init();
 
-    // BackupData read_data = backup_sram_read();
-    // uint32_t reset_count = 0;
-    // if(check_backup_checksum(read_data))
-    //     reset_count = read_data.reset_count;
-    // BackupData write_data={};
-    // write_data.reset_count=++reset_count;
-    // write_data.error_code=0xDEADBEEF;
-    // write_data.checksum=generate_backup_checksum(write_data);
-    // delay(300);
-    // backup_sram_write(write_data);
-    // restart();
-
     // check for and process backup data if it exists
     BackupData read_data;
-    // backup_sram_read(reinterpret_cast<void*>(&read_data), sizeof(read_data));
     backup_sram_read(&read_data, sizeof(read_data));
 
     uint32_t reset_count = 0;
@@ -100,7 +94,6 @@ int main()
     write_data.reset_count = ++reset_count; // increment reset counter
     write_data.some_data = 0xDEADBEEF;
     write_data.checksum = write_data.compute_checksum();
-    // backup_sram_write(reinterpret_cast<const void*>(&write_data), sizeof(write_data));
     backup_sram_write(&write_data, sizeof(write_data));
 
     restart();

--- a/include/backup_sram.h
+++ b/include/backup_sram.h
@@ -2,11 +2,10 @@
 #define BACKUP_SRAM_H
 
 #include <stdint.h>
-#include "board.h"
 
 void backup_sram_init();
-void backup_sram_write(const rosflight_firmware::BackupData&);
-rosflight_firmware::BackupData backup_sram_read();
-bool check_backup_checksum(const rosflight_firmware::BackupData&);
-uint32_t generate_backup_checksum(const rosflight_firmware::BackupData&);
+void backup_sram_write(const void *src, size_t len);
+void backup_sram_read(void *dst, size_t len);
+void backup_sram_clear(size_t len);
+
 #endif // BACKUP_SRAM_H

--- a/src/backup_sram.cpp
+++ b/src/backup_sram.cpp
@@ -5,10 +5,6 @@
 
 void backup_sram_init()
 {
-    //The checksum function depends on the BackupData struct being a multiple of 32 bits
-    //If you change the BackupData struct, and it trips on this static_assert,
-    //either make the BackupData struct a multiple of 32 bits, or change the checksum method
-    static_assert(sizeof(rosflight_firmware::BackupData)%4==0,"Error with debug_info_t: Size is not multiple of 32 bits");
 #pragma GCC diagnostic push //Ignore old style cast from included library
 #pragma GCC diagnostic ignored "-Wold-style-cast"
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_PWR, DISABLE);
@@ -18,52 +14,28 @@ void backup_sram_init()
     PWR_BackupRegulatorCmd(ENABLE);
 }
 
-void backup_sram_write(const rosflight_firmware::BackupData& data)
+void backup_sram_write(const void *src, size_t len)
 {
     PWR_BackupAccessCmd(ENABLE);
 #pragma GCC diagnostic push //Ignore old style cast from included library
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-    std::memcpy(reinterpret_cast<void*>(BKPSRAM_BASE),&data,sizeof(rosflight_firmware::BackupData));
+    std::memcpy(reinterpret_cast<void*>(BKPSRAM_BASE), src, len);
 #pragma GCC diagnostic pop
     PWR_BackupAccessCmd(DISABLE);
 }
 
-//This method actually reads the backup sram, and then clears it.
-//This is used by the backup_sram_read() function, and should not
-//be used elsewhere.
-rosflight_firmware::BackupData do_first_read() {
+void backup_sram_read(void *dst, size_t len)
+{
 #pragma GCC diagnostic push //Ignore old style cast from included library
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-    rosflight_firmware::BackupData data = *(reinterpret_cast<rosflight_firmware::BackupData*>(BKPSRAM_BASE));
+    std::memcpy(dst, reinterpret_cast<const void*>(BKPSRAM_BASE), len);
 #pragma GCC diagnostic pop
+}
+
+void backup_sram_clear(size_t len)
+{
 #pragma GCC diagnostic push //Ignore blank fields in struct
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-    rosflight_firmware::BackupData blank_data = {0};
+    std::memset(reinterpret_cast<void*>(BKPSRAM_BASE), 0, len);
 #pragma GCC diagnostic pop
-    if(!check_backup_checksum(data))
-        data=blank_data;
-    backup_sram_write(blank_data);
-    return data;
-}
-
-rosflight_firmware::BackupData backup_sram_read()
-{
-    static rosflight_firmware::BackupData data = do_first_read();
-    return data;
-}
-
-bool check_backup_checksum(const rosflight_firmware::BackupData& data)
-{
-    return (data.checksum==generate_backup_checksum(data));
-}
-
-//Generates a checksum by XORing 32 bit chunks of the backup data together,
-//excluding the last 32 bits, which stores the checksum itself
-uint32_t generate_backup_checksum(const rosflight_firmware::BackupData& data)
-{
-    const uint32_t* pointer = reinterpret_cast<const uint32_t*>(&data);
-    uint32_t checksum = 0;
-    for(uint8_t i=0;i<(sizeof (rosflight_firmware::BackupData)/4)-1;i++)
-        checksum^=*(pointer+i);
-    return checksum;
 }

--- a/src/backup_sram.cpp
+++ b/src/backup_sram.cpp
@@ -34,8 +34,10 @@ void backup_sram_read(void *dst, size_t len)
 
 void backup_sram_clear(size_t len)
 {
-#pragma GCC diagnostic push //Ignore blank fields in struct
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+    PWR_BackupAccessCmd(ENABLE);
+#pragma GCC diagnostic push //Ignore old style cast from included library
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     std::memset(reinterpret_cast<void*>(BKPSRAM_BASE), 0, len);
 #pragma GCC diagnostic pop
+    PWR_BackupAccessCmd(DISABLE);
 }


### PR DESCRIPTION
Primarily this removes the dependencies on the rosflight firmware, and makes the API more generic.\