### PR TITLE
UART Fixes

### DIFF
--- a/include/revo_f4.h
+++ b/include/revo_f4.h
@@ -65,7 +65,7 @@ const uart_hardware_struct_t uart_config[NUM_UART] =
 {
   {USART1, GPIOA, GPIO_Pin_10, GPIO_Pin_9, GPIO_PinSource10, GPIO_PinSource9,
    GPIO_AF_USART1, USART1_IRQn, DMA2_Stream5_IRQn, DMA2_Stream7_IRQn, DMA2_Stream5,
-   DMA2_Stream7, DMA_Channel_4, DMA_IT_TCIF2, DMA_IT_TCIF7},
+   DMA2_Stream7, DMA_Channel_4, DMA_IT_TCIF5, DMA_IT_TCIF7},
   {USART2, GPIOA, GPIO_Pin_10, GPIO_Pin_9, GPIO_PinSource10, GPIO_PinSource9,
    GPIO_AF_USART2, USART2_IRQn, DMA1_Stream5_IRQn, DMA1_Stream6_IRQn, DMA1_Stream5,
    DMA1_Stream6, DMA_Channel_5, DMA_IT_TCIF5, DMA_IT_TCIF6},

--- a/src/uart.cpp
+++ b/src/uart.cpp
@@ -45,7 +45,7 @@ void UART::init(const uart_hardware_struct_t* conf, uint32_t baudrate, uart_mode
 
   //initialize pins
   rx_pin_.init(c_->GPIO, c_->Rx_Pin, GPIO::PERIPH_IN_OUT);
-  tx_pin_.init(c_->GPIO, c_->Tx_Pin, GPIO::PERIPH_IN_OUT);
+  tx_pin_.init(c_->GPIO, c_->Tx_Pin, GPIO::PERIPH_OUT);
   GPIO_PinAFConfig(c_->GPIO, c_->Rx_PinSource, c_->GPIO_AF);
   GPIO_PinAFConfig(c_->GPIO, c_->Tx_PinSource, c_->GPIO_AF);
 


### PR DESCRIPTION
This fixes the bugs where UART did not work beyond low baud rates.  With these small changes, I was able to pull 2-3 MBd, which is at the limit for FTDI, and near the limit for the STM32F405. Tested with both the uart example and ROSflight serial.
3 MBd is a bit touchy, though.