### PR TITLE
Init checks

### DIFF
--- a/include/hmc5883l.h
+++ b/include/hmc5883l.h
@@ -89,9 +89,9 @@ public:
   bool read(float mag_data[]);
   bool present();
   void cb(uint8_t result);
-
+  inline bool is_initialized(){return i2c_;}
 private:
-  I2C* i2c_;
+  I2C *i2c_{nullptr};
   uint8_t i2c_buf_[6];
   volatile float data_[3];
   uint32_t last_update_ms_;

--- a/include/hmc5883l.h
+++ b/include/hmc5883l.h
@@ -96,5 +96,5 @@ private:
   volatile float data_[3];
   uint32_t last_update_ms_;
   uint32_t next_update_ms_;
-  bool mag_present_;
+  bool mag_present_{false};
 };

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -89,7 +89,8 @@ private:
   volatile uint8_t return_code_;
   bool subaddress_sent_ = false;
   bool done_ = false;
-  
+  bool initialized_ = false;
+
   volatile uint8_t  addr_;
   volatile uint8_t  reg_;
   volatile uint8_t  len_;
@@ -135,7 +136,9 @@ public:
   void unstick();
   void hardware_failure();
   bool check_busy();
-  int8_t read(uint8_t addr, uint8_t reg, uint8_t num_bytes, uint8_t* data, void(*callback)(uint8_t) = nullptr, bool blocking = false);
+  bool is_initialized(){return initialized_;}
+  int8_t read(uint8_t addr, uint8_t reg, uint8_t num_bytes, uint8_t *data, void(*callback)(uint8_t) = nullptr,
+              bool blocking = false);
   int8_t write(uint8_t addr, uint8_t reg, uint8_t data, void(*callback)(uint8_t), bool blocking = false);
   
   int8_t write(uint8_t addr, uint8_t reg, uint8_t data);

--- a/include/mb1242.h
+++ b/include/mb1242.h
@@ -64,8 +64,8 @@ private:
     I2C *i2c_; // The i2c object used for communication
     bool ready_to_ping_; // Whether the sensor is ready to make another measurement
     uint8_t buffer_[2]; // for receiving data from the sensor
-    bool sensor_present_; // Flag of whether we have received data from the sensor
-
+    bool sensor_present_{false}; // Flag of whether we have received data from the sensor
+    bool sensor_initialized_{false}; // Whether the init function has been called yet
 
 public:
     I2CSonar();

--- a/include/mb1242.h
+++ b/include/mb1242.h
@@ -75,6 +75,7 @@ public:
     void update(); // Tries to either start a measurement, or read it from the sensor
     // update will do nothing if it has done something in the last MB1242_UPDATE_WAIT_MILLIS ms
     // Calling it more frequently won't break anything
+    inline bool is_initialized(){return sensor_initialized_;}
 
     // Callbacks. For internal use only, but public so the I2C peripheral can call them
     void cb_start_read(uint8_t result); // callback after the measure command has been sent to the sensor

--- a/include/mpu6000.h
+++ b/include/mpu6000.h
@@ -164,13 +164,14 @@ public:
   void read(float *accel_data, float *gyro_data, float *temp_data, uint64_t *time_us);
   void data_transfer_callback();
   void exti_cb();
-  bool new_data(); 
+  bool new_data();
+  inline bool is_initialized(){return spi;}
 
 private:
   void write(uint8_t reg, uint8_t data);
   bool new_data_ = false;
   uint64_t imu_timestamp_ = 0;
-  SPI* spi;
+  SPI *spi{nullptr};
   GPIO exti_;
   GPIO cs_;
   float accel_scale_;

--- a/include/ms4525.h
+++ b/include/ms4525.h
@@ -43,11 +43,12 @@ public:
   void read(float *differential_pressure, float *temp);
 
   void read_cb(uint8_t result);
+  inline bool is_initialized(){return i2c_;}
 
 private:
   static const uint8_t ADDR = 0x28;
 
-  I2C* i2c_;
+  I2C *i2c_{nullptr};
   uint8_t buf_[4];
   float diff_press_;
   float temp_;

--- a/include/ms5611.h
+++ b/include/ms5611.h
@@ -87,7 +87,7 @@ private:
   bool start_pres_meas();
   void convert();
 
-  I2C* i2c_;
+  I2C *i2c_{nullptr};
   uint8_t pres_buf_[3];
   uint8_t temp_buf_[3];
   int32_t pres_raw_;
@@ -119,6 +119,7 @@ public:
   void pres_start_cb(uint8_t result);
   void write_zero_cb(uint8_t result);
   void reset_cb(uint8_t result);
+  inline bool is_initialized(){return i2c_;}
 };
 
 

--- a/include/ms5611.h
+++ b/include/ms5611.h
@@ -100,7 +100,7 @@ private:
   uint32_t last_update_ms_;
   bool waiting_for_cb_;
   bool new_data_;
-  bool baro_present_;
+  bool baro_present_{false};
   
   callback_type_t callback_type_;
 

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -120,6 +120,7 @@ void I2C::init(const i2c_hardware_struct_t *c)
   
   unstick(); //unsti1ck will properly initialize pins
   log_line;
+  initialized_ = true;
 }
 
 void I2C::unstick()

--- a/src/mb1242.cpp
+++ b/src/mb1242.cpp
@@ -67,6 +67,7 @@ void I2CSonar::init(I2C *_i2c)
     sensor_present_ = false;
     last_callback_ms_ = 0;
   }
+  sensor_initialized_ = true;
 }
 
 bool I2CSonar::present()
@@ -83,6 +84,8 @@ bool I2CSonar::present()
 // Feel free to call it more often, though.
 void I2CSonar::update()
 {
+  if(!sensor_initialized_)
+    return;
   uint64_t now=millis();
   if (now > (last_update_ms_ + MB1242_UPDATE_WAIT_MILLIS))
   {


### PR DESCRIPTION
This is to be merged after the Battery Monitor support is merged.

This PR adds support for checking if certain peripherals, such as I2C's are initialized. This is to support the config manager feature in ROSflight, by allowing these peripherals to be enabled when needed, but only once.