### PR TITLE
Fix PWM 11 overriding PPM

### DIFF
--- a/include/revo_f4.h
+++ b/include/revo_f4.h
@@ -100,11 +100,11 @@ const uart_hardware_struct_t uart_config[NUM_UART] =
 //} spi_hardware_struct_t;
 const spi_hardware_struct_t spi_config[NUM_SPI] =
 {
-  { SPI1, GPIOA, GPIO_PinSource5, GPIO_Pin_5, GPIO_PinSource6, GPIO_Pin_6, GPIO_PinSource7, GPIO_Pin_7, 
+  { SPI1, GPIOA, GPIO_PinSource5, GPIO_Pin_5, GPIO_PinSource6, GPIO_Pin_6, GPIO_PinSource7, GPIO_Pin_7,
     GPIO_AF_SPI1, DMA2_Stream3_IRQn, DMA2_Stream3, DMA2_Stream2, DMA_Channel_3, DMA_FLAG_TCIF3, DMA_FLAG_TCIF2 },
   {	SPI2, GPIOB, GPIO_PinSource13, GPIO_Pin_13, GPIO_PinSource15, GPIO_Pin_15, GPIO_PinSource14, GPIO_Pin_14,
     GPIO_AF_SPI2, DMA1_Stream4_IRQn, DMA1_Stream4, DMA1_Stream3, DMA_Channel_0, DMA_FLAG_TCIF4, DMA_FLAG_TCIF3 },
-  { SPI3, GPIOC, GPIO_PinSource10, GPIO_Pin_10, GPIO_PinSource12, GPIO_Pin_12,GPIO_PinSource11, GPIO_Pin_11, 
+  { SPI3, GPIOC, GPIO_PinSource10, GPIO_Pin_10, GPIO_PinSource12, GPIO_Pin_12,GPIO_PinSource11, GPIO_Pin_11,
     GPIO_AF_SPI3, DMA1_Stream5_IRQn, DMA1_Stream5, DMA1_Stream2, DMA_Channel_0, DMA_FLAG_TCIF5, DMA_FLAG_TCIF2 }
 };
 #define MPU6000_SPI 0
@@ -118,10 +118,10 @@ const spi_hardware_struct_t spi_config[NUM_SPI] =
 /////////////////////// I2C CONFIG ///////////////////////
 #define NUM_I2C 2
 const i2c_hardware_struct_t i2c_config[NUM_I2C] = {
-  { I2C1, 400000, I2C1_EV_IRQn, I2C1_ER_IRQn, GPIOB, GPIO_AF_I2C1, GPIO_PinSource8, GPIO_Pin_8, 
-  	GPIO_PinSource9, GPIO_Pin_9, DMA1_Stream0, DMA_Channel_1, DMA1_Stream0_IRQn, DMA_FLAG_TCIF0 },
-  { I2C2, 100000, I2C2_EV_IRQn, I2C2_ER_IRQn, GPIOB, GPIO_AF_I2C2, GPIO_PinSource10, GPIO_Pin_10, 
-  	GPIO_PinSource11, GPIO_Pin_11, DMA1_Stream2, DMA_Channel_7, DMA1_Stream2_IRQn, DMA_FLAG_TCIF2 }
+  { I2C1, 400000, I2C1_EV_IRQn, I2C1_ER_IRQn, GPIOB, GPIO_AF_I2C1, GPIO_PinSource8, GPIO_Pin_8,
+    GPIO_PinSource9, GPIO_Pin_9, DMA1_Stream0, DMA_Channel_1, DMA1_Stream0_IRQn, DMA_FLAG_TCIF0 },
+  { I2C2, 100000, I2C2_EV_IRQn, I2C2_ER_IRQn, GPIOB, GPIO_AF_I2C2, GPIO_PinSource10, GPIO_Pin_10,
+    GPIO_PinSource11, GPIO_Pin_11, DMA1_Stream2, DMA_Channel_7, DMA1_Stream2_IRQn, DMA_FLAG_TCIF2 }
 };
 #define MAG_I2C 0
 #define BARO_I2C 0
@@ -135,7 +135,7 @@ const i2c_hardware_struct_t i2c_config[NUM_I2C] = {
 
 /////////////////////// PWM CONFIG ///////////////////////
 #define PWM_NUM_CHANNELS 13
-#define PWM_NUM_OUTPUTS 11
+#define PWM_NUM_OUTPUTS 10
 //typedef struct {
 //	GPIO_TypeDef* GPIO;
 //	uint16_t GPIO_Pin;
@@ -158,7 +158,7 @@ const pwm_hardware_struct_t pwm_config[PWM_NUM_CHANNELS] =
   {GPIOC, GPIO_Pin_8,  GPIO_PinSource8,  TIM8,  TIM_Channel_3, GPIO_AF_TIM8, TIM8_CC_IRQn, TIM_IT_CC3, }, // RC 5 (Flexi-9)
   {GPIOC, GPIO_Pin_7,  GPIO_PinSource7,  TIM8,  TIM_Channel_2, GPIO_AF_TIM8, TIM8_CC_IRQn, TIM_IT_CC2, }, // RC 4 (Flexi-8)
   {GPIOC, GPIO_Pin_6,  GPIO_PinSource6,  TIM8,  TIM_Channel_1, GPIO_AF_TIM8, TIM8_CC_IRQn, TIM_IT_CC1, }, // RC 3 (Flexi-7)
-  {GPIOB, GPIO_Pin_15, GPIO_PinSource15, TIM12, TIM_Channel_2, GPIO_AF_TIM12, TIM8_BRK_TIM12_IRQn, TIM_IT_CC2, }, // RC2 (Flexi-6)
+  {GPIOB, GPIO_Pin_15, GPIO_PinSource15, TIM12, TIM_Channel_2, GPIO_AF_TIM12, TIM8_BRK_TIM12_IRQn, TIM_IT_CC2, }, // RC2 (Flexi-6) // Note: Conflicts with PPM. Do not use if PPM is enabled. This may cause unsafe behavior
   {GPIOB, GPIO_Pin_14, GPIO_PinSource14, TIM12, TIM_Channel_1, GPIO_AF_TIM12, TIM8_BRK_TIM12_IRQn, TIM_IT_CC1, }, // RC1 (Flexi-5) // Used for PPM RC
   {GPIOA, GPIO_Pin_8,  GPIO_PinSource8,  TIM1,  TIM_Channel_1, GPIO_AF_TIM1, TIM1_CC_IRQn, TIM_IT_CC1, }, // Buzzer
 };


### PR DESCRIPTION
This prevents a conflict between PWM 11 and PPM, which could cause issues ranging from broken PWM output to the aircraft arming during parameter changes.