### PR TITLE
Fix USB driver conflict with backup SRAM driver

### DIFF
--- a/lib/vcp/usb_bsp.c
+++ b/lib/vcp/usb_bsp.c
@@ -83,7 +83,7 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
     RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_OTG_FS, ENABLE) ;
 
     /* enable the PWR clock */
-    RCC_APB1PeriphResetCmd(RCC_APB1Periph_PWR, ENABLE);
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_PWR, ENABLE);
 
     EXTI_ClearITPendingBit(EXTI_Line0);
 }


### PR DESCRIPTION
There appears to be a typo in the VCP driver that sets a wrong register. This breaks the Backup SRAM functionality. This pull fixes the typo.
