### PR TITLE
Fix missing include in backup_sram

### DIFF
--- a/include/backup_sram.h
+++ b/include/backup_sram.h
@@ -1,6 +1,7 @@
 #ifndef BACKUP_SRAM_H
 #define BACKUP_SRAM_H
 
+#include <cstddef>
 #include <stdint.h>
 
 void backup_sram_init();


### PR DESCRIPTION
The reformat reordered some includes in backup_sram.cpp, which mean that `size_t` was not defined in backup_sram.h. This PR adds the requisite include.